### PR TITLE
Add an initial delay before start querying

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,11 +18,11 @@ steps:
     GO111MODULE: on
     GOPROXY: https://proxy.golang.org
 
-- name: fmt
+- name: lint
   pull: always
   image: golang:1.13
   commands:
-  - fmt_res=$(gofmt -d -s $(find . -type f -name '*.go' -not -path './vendor/*')); if [ -n "$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$fmt_res"; exit 1; fi
+  - make lint
 
 - name: build
   pull: always

--- a/.errcheck_excludes
+++ b/.errcheck_excludes
@@ -1,0 +1,1 @@
+(github.com/go-kit/kit/log.Logger).Log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters-settings:
   lll:
     line-length: 140
   funlen:
-    lines: 130
+    lines: 140
     statements: 60
   gocognit:
     min-complexity: 40

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters-settings:
   lll:
     line-length: 140
   funlen:
-    lines: 100
+    lines: 120
     statements: 45
   gocognit:
     min-complexity: 40

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters-settings:
   lll:
     line-length: 140
   funlen:
-    lines: 140
-    statements: 60
+    lines: 100
+    statements: 45
   gocognit:
     min-complexity: 40

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 3m
+  tests: true
+
+linters-settings:
+  errcheck:
+    exclude: .errcheck_excludes
+  lll:
+    line-length: 140
+  funlen:
+    lines: 130
+    statements: 60
+  gocognit:
+    min-complexity: 40

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 EMBEDMD ?= $(FIRST_GOPATH)/bin/embedmd
+GOLANGCILINT ?= $(FIRST_GOPATH)/bin/golangci-lint
+GOLANGCILINT_VERSION ?= v1.21.0
 
 all: build
 
@@ -8,6 +10,18 @@ build: up
 .PHONY: up
 up:
 	CGO_ENABLED=0 go build -v -ldflags '-w -extldflags '-static''
+
+.PHONY: format
+format: $(GOLANGCILINT) go-fmt
+	$(GOLANGCILINT) run --fix --enable-all -c .golangci.yml
+
+.PHONY: go-fmt
+go-fmt:
+	@fmt_res=$$(gofmt -d -s $$(find . -type f -name '*.go' -not -path './vendor/*' -not -path './jsonnet/vendor/*')); if [ -n "$$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$$fmt_res"; exit 1; fi
+
+.PHONY: lint
+lint: $(GOLANGCILINT) format
+	$(GOLANGCILINT) run -v --enable-all -c .golangci.yml
 
 container: Dockerfile up
 	docker build -t quay.io/observatorium/up:latest .
@@ -27,3 +41,8 @@ README.md: $(EMBEDMD) tmp/help.txt
 
 $(EMBEDMD):
 	GO111MODULE=off go get -u github.com/campoy/embedmd
+
+$(GOLANGCILINT):
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCILINT_VERSION)/install.sh \
+		| sed -e '/install -d/d' \
+		| sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCILINT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ go-fmt:
 	@fmt_res=$$(gofmt -d -s $$(find . -type f -name '*.go' -not -path './vendor/*' -not -path './jsonnet/vendor/*')); if [ -n "$$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$$fmt_res"; exit 1; fi
 
 .PHONY: lint
-lint: $(GOLANGCILINT) format
+lint: $(GOLANGCILINT)
 	$(GOLANGCILINT) run -v --enable-all -c .golangci.yml
 
 container: Dockerfile up

--- a/README.md
+++ b/README.md
@@ -31,16 +31,14 @@ docker run --rm -p 8080:8080 quay.io/observatorium/up --endpoint=https://example
 [embedmd]:# (tmp/help.txt)
 ```txt
 Usage of ./up:
-  -address-read string
-    	The base address to which to make query requests to. (/api/v1/query* will be appended to given address)
   -duration duration
     	The duration of the up command to run until it stops. (default 5m0s)
   -endpoint-write string
     	The endpoint to which to make remote-write requests.
-  -initial-query-wait duration
-    	The time to wait before executing first query. (default 5s)
-  -labels value
-    	The labels that should be applied to remote-write requests.
+  -initial-query-delay duration
+    	The time to wait before executing the first query. (default 5s)
+  -labels __name__
+    	The labels additionally to __name__ that should be applied to remote-write requests.
   -latency duration
     	The maximum allowable latency between writing and reading. (default 15s)
   -listen string
@@ -49,6 +47,8 @@ Usage of ./up:
     	The name of the metric to send in remote-write requests. (default "up")
   -period duration
     	The time to wait between remote-write requests. (default 5s)
+  -read-address string
+    	The base address to which to make query requests to. (/api/v1/query* will be appended to the given address)
   -threshold float
     	The percentage of successful requests needed to succeed overall. 0 - 1. (default 0.9)
   -token string

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ docker run --rm -p 8080:8080 quay.io/observatorium/up --endpoint=https://example
 [embedmd]:# (tmp/help.txt)
 ```txt
 Usage of ./up:
+  -address-read string
+    	The base address to which to make query requests to. (/api/v1/query* will be appended to given address)
   -duration duration
     	The duration of the up command to run until it stops. (default 5m0s)
-  -endpoint-read string
-    	The endpoint to which to make query requests to.
   -endpoint-write string
     	The endpoint to which to make remote-write requests.
+  -initial-query-wait duration
+    	The time to wait before executing first query. (default 5s)
   -labels value
     	The labels that should be applied to remote-write requests.
   -latency duration

--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ docker run --rm -p 8080:8080 quay.io/observatorium/up --endpoint=https://example
 Usage of ./up:
   -duration duration
     	The duration of the up command to run until it stops. (default 5m0s)
+  -endpoint-read string
+    	The endpoint to which to make query requests.
   -endpoint-write string
     	The endpoint to which to make remote-write requests.
   -initial-query-delay duration
     	The time to wait before executing the first query. (default 5s)
-  -labels __name__
-    	The labels additionally to __name__ that should be applied to remote-write requests.
+  -labels value
+    	The labels additionally to '__name__' that should be applied to remote-write requests.
   -latency duration
     	The maximum allowable latency between writing and reading. (default 15s)
   -listen string
@@ -47,8 +49,6 @@ Usage of ./up:
     	The name of the metric to send in remote-write requests. (default "up")
   -period duration
     	The time to wait between remote-write requests. (default 5s)
-  -read-address string
-    	The base address to which to make query requests to. (/api/v1/query* will be appended to the given address)
   -threshold float
     	The percentage of successful requests needed to succeed overall. 0 - 1. (default 0.9)
   -token string

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ Usage of ./up:
   -initial-query-delay duration
     	The time to wait before executing the first query. (default 5s)
   -labels value
-    	The labels additionally to '__name__' that should be applied to remote-write requests.
+    	The labels in addition to '__name__' that should be applied to remote-write requests.
   -latency duration
     	The maximum allowable latency between writing and reading. (default 15s)
   -listen string
     	The address on which internal server runs. (default ":8080")
+  -log.level string
+    	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
   -name string
     	The name of the metric to send in remote-write requests. (default "up")
   -period duration

--- a/main.go
+++ b/main.go
@@ -306,7 +306,7 @@ func parseOptions() (options, error) {
 	return opts, err
 }
 
-func read(ctx context.Context, endpoint fmt.Stringer, labels []prompb.Label, ago time.Duration, latency time.Duration, m metrics) error {
+func read(ctx context.Context, endpoint fmt.Stringer, labels []prompb.Label, ago, latency time.Duration, m metrics) error {
 	client, err := promapi.NewClient(promapi.Config{Address: endpoint.String()})
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -505,12 +505,11 @@ func generate(labels []prompb.Label) *prompb.WriteRequest {
 }
 
 func exhaustCloseWithLogOnErr(l log.Logger, rc io.ReadCloser) {
-	_, err := io.Copy(ioutil.Discard, rc)
-	if err != nil {
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
 		level.Warn(l).Log("msg", "failed to exhaust reader, performance may be impeded", "err", err)
 	}
 
-	if err = rc.Close(); err != nil {
+	if err := rc.Close(); err != nil {
 		level.Warn(l).Log("msg", "detected close error", "err", errors.Wrap(err, "response body close"))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -31,111 +31,79 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-var (
-	remoteWriteRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "up_remote_writes_total",
-		Help: "Total number of remote write requests.",
-	}, []string{"result"})
-	queryResponses = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "up_queries_total",
-		Help: "The total number of queries made.",
-	}, []string{"result"})
-	metricValueDifference = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "up_metric_value_difference",
-		Help:    "The time difference between the current timestamp and the timestamp in the metrics value.",
-		Buckets: prometheus.LinearBuckets(4, 0.25, 16),
-	})
-)
-
 type labelArg []prompb.Label
 
 func (la *labelArg) String() string {
-	var ls []string
-	for _, l := range *la {
-		ls = append(ls, l.Name+"="+l.Value)
+	ls := make([]string, len(*la))
+	for i, l := range *la {
+		ls[i] = l.Name + "=" + l.Value
 	}
+
 	return strings.Join(ls, ", ")
 }
 
 func (la *labelArg) Set(v string) error {
-	var lset []prompb.Label
-	for _, l := range strings.Split(v, ",") {
+	labels := strings.Split(v, ",")
+	lset := make([]prompb.Label, len(labels))
+
+	for i, l := range labels {
 		parts := strings.SplitN(l, "=", 2)
 		if len(parts) != 2 {
 			return errors.Errorf("unrecognized label %q", l)
 		}
-		if !model.LabelName.IsValid(model.LabelName(string(parts[0]))) {
+
+		if !model.LabelName.IsValid(model.LabelName(parts[0])) {
 			return errors.Errorf("unsupported format for label %s", l)
 		}
+
 		val, err := strconv.Unquote(parts[1])
 		if err != nil {
 			return errors.Wrap(err, "unquote label value")
 		}
-		lset = append(lset, prompb.Label{Name: parts[0], Value: val})
+
+		lset[i] = prompb.Label{Name: parts[0], Value: val}
 	}
+
 	*la = lset
+
 	return nil
 }
 
+type options struct {
+	WriteEndpoint *url.URL
+	ReadAddress   *url.URL
+	// ReadEndpoint     *url.URL
+	Labels           labelArg
+	Listen           string
+	Name             string
+	Token            string
+	Period           time.Duration
+	Duration         time.Duration
+	Latency          time.Duration
+	InitialQueryWait time.Duration
+	SuccessThreshold float64
+}
+
+type metrics struct {
+	remoteWriteRequests   *prometheus.CounterVec
+	queryResponses        *prometheus.CounterVec
+	metricValueDifference prometheus.Histogram
+	reporterCounter       *prometheus.CounterVec
+}
+
 func main() {
-	opts := struct {
-		EndpointWrite    string
-		EndpointRead     string
-		Labels           labelArg
-		Listen           string
-		Name             string
-		Token            string
-		Period           time.Duration
-		Duration         time.Duration
-		SuccessThreshold float64
-		Latency          time.Duration
-	}{}
-
-	flag.StringVar(&opts.EndpointWrite, "endpoint-write", "", "The endpoint to which to make remote-write requests.")
-	flag.StringVar(&opts.EndpointRead, "endpoint-read", "", "The endpoint to which to make query requests to.")
-	flag.Var(&opts.Labels, "labels", "The labels that should be applied to remote-write requests.")
-	flag.StringVar(&opts.Listen, "listen", ":8080", "The address on which internal server runs.")
-	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
-	flag.StringVar(&opts.Token, "token", "", "The bearer token to set in the authorization header on remote-write requests.")
-	flag.DurationVar(&opts.Period, "period", 5*time.Second, "The time to wait between remote-write requests.")
-	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute, "The duration of the up command to run until it stops.")
-	flag.Float64Var(&opts.SuccessThreshold, "threshold", 0.9, "The percentage of successful requests needed to succeed overall. 0 - 1.")
-	flag.DurationVar(&opts.Latency, "latency", 15*time.Second, "The maximum allowable latency between writing and reading.")
-	flag.Parse()
-
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.WithPrefix(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.WithPrefix(logger, "caller", log.DefaultCaller)
 
-	endpointWrite, err := url.ParseRequestURI(opts.EndpointWrite)
+	opts, err := parseOptions()
 	if err != nil {
-		level.Error(logger).Log("msg", "--endpoint-write is invalid", "err", err)
-		return
+		level.Error(logger).Log("msg", "option parse", "err", err)
+		os.Exit(1)
 	}
-
-	var endpointRead *url.URL
-	if opts.EndpointRead != "" {
-		endpointRead, err = url.ParseRequestURI(opts.EndpointRead)
-		if err != nil {
-			level.Error(logger).Log("msg", "--endpoint-read is invalid", "err", err)
-			return
-		}
-	}
-
-	opts.Labels = append(opts.Labels, prompb.Label{
-		Name:  "__name__",
-		Value: opts.Name,
-	})
 
 	reg := prometheus.NewRegistry()
-	reg.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
-		remoteWriteRequests,
-		queryResponses,
-		metricValueDifference,
-	)
-
+	m := registerMetrics(reg, opts)
 	ctx := context.Background()
 
 	var g run.Group
@@ -150,11 +118,12 @@ func main() {
 		}, func(_ error) {
 			close(sig)
 
-			success, errors := successerrors(logger)
+			success, errors := successerrors(logger, m)
 			level.Info(logger).Log("msg", "number of requests", "success", success, "errors", errors)
 		})
 	}
 	{
+		logger := log.With(logger, "component", "http")
 		router := http.NewServeMux()
 		router.Handle("/metrics", promhttp.InstrumentMetricHandler(reg, promhttp.HandlerFor(reg, promhttp.HandlerOpts{})))
 		router.HandleFunc("/debug/pprof/", pprof.Index)
@@ -178,6 +147,7 @@ func main() {
 		})
 	}
 	{
+		logger := log.With(logger, "component", "writer")
 		t := time.NewTicker(opts.Period)
 		ctx, cancel := context.WithCancel(ctx)
 
@@ -186,7 +156,7 @@ func main() {
 			for {
 				select {
 				case <-t.C:
-					if err := write(ctx, endpointWrite, opts.Token, generate(opts.Labels)); err != nil {
+					if err := write(ctx, opts.WriteEndpoint, opts.Token, generate(opts.Labels), m); err != nil {
 						level.Error(logger).Log("msg", "failed to make request", "err", err)
 					}
 				case <-ctx.Done():
@@ -199,30 +169,33 @@ func main() {
 		})
 	}
 	{
-		var cancel func()
+		if opts.ReadAddress != nil {
+			logger := log.With(logger, "component", "querier")
+			t := time.NewTicker(opts.Period)
 
-		if opts.Duration != 0 {
-			ctx, cancel = context.WithTimeout(ctx, opts.Duration)
-		} else {
-			ctx, cancel = context.WithCancel(ctx)
-		}
+			var cancel func()
+			if opts.Duration != 0 {
+				ctx, cancel = context.WithTimeout(ctx, opts.Duration+opts.Period)
+			} else {
+				ctx, cancel = context.WithCancel(ctx)
+			}
 
-		t := time.NewTicker(opts.Period)
-
-		if opts.EndpointRead != "" {
 			g.Add(func() error {
+				level.Info(logger).Log("msg", "waiting for a single period before querying for metrics")
+				time.Sleep(opts.InitialQueryWait)
+
 				level.Info(logger).Log("msg", "start querying for metrics")
 				for {
 					select {
 					case <-t.C:
-						if err := read(ctx, endpointRead, opts.Labels, opts.Latency); err != nil {
-							queryResponses.WithLabelValues("error").Inc()
+						if err := read(ctx, opts.ReadAddress, opts.Labels, -1*(opts.InitialQueryWait-opts.Period), opts.Latency, m); err != nil {
+							m.queryResponses.WithLabelValues("error").Inc()
 							level.Error(logger).Log("msg", "failed to query", "err", err)
 						} else {
-							queryResponses.WithLabelValues("success").Inc()
+							m.queryResponses.WithLabelValues("success").Inc()
 						}
 					case <-ctx.Done():
-						success, errors := successerrors(logger)
+						success, errors := successerrors(logger, m)
 						ratio := success / (success + errors)
 
 						if ratio < opts.SuccessThreshold {
@@ -241,22 +214,114 @@ func main() {
 	if err := g.Run(); err != nil {
 		stdlog.Fatal(err)
 	}
+
+	level.Info(logger).Log("msg", "up completed its mission!")
 }
 
-func read(ctx context.Context, endpoint *url.URL, labels []prompb.Label, latency time.Duration) error {
+func registerMetrics(reg *prometheus.Registry, opts options) metrics {
+	m := metrics{
+		remoteWriteRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "up_remote_writes_total",
+			Help: "Total number of remote write requests.",
+		}, []string{"result"}),
+		queryResponses: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "up_queries_total",
+			Help: "The total number of queries made.",
+		}, []string{"result"}),
+		metricValueDifference: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "up_metric_value_difference",
+			Help:    "The time difference between the current timestamp and the timestamp in the metrics value.",
+			Buckets: prometheus.LinearBuckets(4, 0.25, 16),
+		}),
+	}
+	reg.MustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		m.remoteWriteRequests,
+		m.queryResponses,
+		m.metricValueDifference,
+	)
+
+	// Used for successerrors reporting.
+	if opts.ReadAddress != nil {
+		m.reporterCounter = m.queryResponses
+	} else {
+		m.reporterCounter = m.remoteWriteRequests
+	}
+
+	return m
+}
+
+func parseOptions() (options, error) {
+	var (
+		rawEndpointWrite string
+		rawEndpointRead  string
+	)
+
+	opts := options{}
+
+	flag.StringVar(&rawEndpointWrite, "endpoint-write", "", "The endpoint to which to make remote-write requests.")
+	flag.StringVar(&rawEndpointRead, "endpoint-read", "", "The endpoint to which to make query requests to.")
+	flag.Var(&opts.Labels, "labels", "The labels that should be applied to remote-write requests.")
+	flag.StringVar(&opts.Listen, "listen", ":8080", "The address on which internal server runs.")
+	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
+	flag.StringVar(&opts.Token, "token", "", "The bearer token to set in the authorization header on remote-write requests.")
+	flag.DurationVar(&opts.Period, "period", 5*time.Second, "The time to wait between remote-write requests.")
+	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute, "The duration of the up command to run until it stops.")
+	flag.Float64Var(&opts.SuccessThreshold, "threshold", 0.9, "The percentage of successful requests needed to succeed overall. 0 - 1.")
+	flag.DurationVar(&opts.Latency, "latency", 15*time.Second, "The maximum allowable latency between writing and reading.")
+	flag.DurationVar(&opts.InitialQueryWait, "initial-query-wait", 5*time.Second, "The time to wait before executing first query.")
+	flag.Parse()
+
+	endpointWrite, err := url.ParseRequestURI(rawEndpointWrite)
+	if err != nil {
+		return opts, fmt.Errorf("--endpoint-write is invalid: %w", err)
+	}
+
+	opts.WriteEndpoint = endpointWrite
+
+	var endpointRead *url.URL
+	if rawEndpointRead != "" {
+		endpointRead, err = url.ParseRequestURI(rawEndpointRead)
+		if err != nil {
+			return opts, fmt.Errorf("--endpoint-read is invalid: %w", err)
+		}
+	}
+
+	opts.ReadAddress = endpointRead
+
+	if opts.Latency <= opts.Period {
+		return opts, errors.New("--latency cannot be less than period")
+	}
+
+	if opts.InitialQueryWait <= opts.Period {
+		return opts, errors.New("--initial-query-wait cannot be less than period")
+	}
+
+	opts.Labels = append(opts.Labels, prompb.Label{
+		Name:  "__name__",
+		Value: opts.Name,
+	})
+
+	return opts, err
+}
+
+func read(ctx context.Context, endpoint fmt.Stringer, labels []prompb.Label, ago time.Duration, latency time.Duration, m metrics) error {
 	client, err := promapi.NewClient(promapi.Config{Address: endpoint.String()})
 	if err != nil {
 		return err
 	}
+
 	a := promv1.NewAPI(client)
 
-	var labelSelectors []string
-	for _, label := range labels {
-		labelSelectors = append(labelSelectors, fmt.Sprintf(`%s="%s"`, label.Name, label.Value))
+	labelSelectors := make([]string, len(labels))
+	for i, label := range labels {
+		labelSelectors[i] = fmt.Sprintf(`%s="%s"`, label.Name, label.Value)
 	}
+
 	query := fmt.Sprintf("{%s}", strings.Join(labelSelectors, ","))
 
-	value, _, err := a.Query(ctx, query, time.Now().Add(-5*time.Second))
+	value, _, err := a.Query(ctx, query, time.Now().Add(ago))
 	if err != nil {
 		return err
 	}
@@ -270,13 +335,84 @@ func read(ctx context.Context, endpoint *url.URL, labels []prompb.Label, latency
 
 	diffSeconds := time.Since(t).Seconds()
 
-	metricValueDifference.Observe(diffSeconds)
+	m.metricValueDifference.Observe(diffSeconds)
 
 	if diffSeconds > latency.Seconds() {
 		return fmt.Errorf("metric value is too old: %2.fs", diffSeconds)
 	}
 
 	return nil
+}
+
+func write(ctx context.Context, endpoint fmt.Stringer, token string, wreq proto.Message, m metrics) error {
+	var (
+		buf []byte
+		err error
+		req *http.Request
+		res *http.Response
+	)
+
+	defer func() {
+		if err != nil {
+			m.remoteWriteRequests.WithLabelValues("error").Inc()
+			return
+		}
+		m.remoteWriteRequests.WithLabelValues("success").Inc()
+	}()
+
+	buf, err = proto.Marshal(wreq)
+	if err != nil {
+		return errors.Wrap(err, "marshalling proto")
+	}
+
+	req, err = http.NewRequest("POST", endpoint.String(), bytes.NewBuffer(snappy.Encode(nil, buf)))
+	if err != nil {
+		return errors.Wrap(err, "creating request")
+	}
+
+	req.Header.Add("Authorization", "Bearer "+token)
+
+	res, err = http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return errors.Wrap(err, "making request")
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		err = errors.New(res.Status)
+		return errors.Wrap(err, "non-200 status")
+	}
+
+	return nil
+}
+
+func successerrors(logger log.Logger, m metrics) (float64, float64) {
+	metrics := make(chan prometheus.Metric, 2)
+	m.reporterCounter.Collect(metrics)
+	close(metrics)
+
+	var success, errors float64
+
+	for m := range metrics {
+		m1 := &dto.Metric{}
+		if err := m.Write(m1); err != nil {
+			level.Warn(logger).Log(
+				"msg", "cannot read success and error count from prometheus counter",
+				"err", err,
+			)
+		}
+
+		for _, l := range m1.Label {
+			switch *l.Value {
+			case "error":
+				errors = m1.GetCounter().GetValue()
+			case "success":
+				success = m1.GetCounter().GetValue()
+			}
+		}
+	}
+
+	return success, errors
 }
 
 func generate(labels []prompb.Label) *prompb.WriteRequest {
@@ -295,67 +431,4 @@ func generate(labels []prompb.Label) *prompb.WriteRequest {
 			},
 		},
 	}
-}
-
-func write(ctx context.Context, endpoint *url.URL, token string, wreq *prompb.WriteRequest) error {
-	var (
-		buf []byte
-		err error
-		req *http.Request
-		res *http.Response
-	)
-	defer func() {
-		if err != nil {
-			remoteWriteRequests.WithLabelValues("error").Inc()
-			return
-		}
-		remoteWriteRequests.WithLabelValues("success").Inc()
-	}()
-	buf, err = proto.Marshal(wreq)
-	if err != nil {
-		return errors.Wrap(err, "marshalling proto")
-	}
-	req, err = http.NewRequest("POST", endpoint.String(), bytes.NewBuffer(snappy.Encode(nil, buf)))
-	if err != nil {
-		return errors.Wrap(err, "creating request")
-	}
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req.WithContext(ctx))
-	if err != nil {
-		return errors.Wrap(err, "making request")
-	}
-	if res.StatusCode != http.StatusOK {
-		err = errors.New(res.Status)
-		return errors.Wrap(err, "non-200 status")
-	}
-	return nil
-}
-
-func successerrors(logger log.Logger) (float64, float64) {
-	metrics := make(chan prometheus.Metric, 2)
-	queryResponses.Collect(metrics)
-	close(metrics)
-
-	var success, errors float64
-
-	for m := range metrics {
-		m1 := &dto.Metric{}
-		err := m.Write(m1)
-		if err != nil {
-			level.Warn(logger).Log(
-				"msg", "cannot read success and error count from prometheus counter",
-				"err", err,
-			)
-		}
-		for _, l := range m1.Label {
-			switch *l.Value {
-			case "error":
-				errors = m1.GetCounter().GetValue()
-			case "success":
-				success = m1.GetCounter().GetValue()
-			}
-		}
-	}
-
-	return success, errors
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,8 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
+const gracefulStopDuration = 5 * time.Second
+
 type labelArg []prompb.Label
 
 func (la *labelArg) String() string {
@@ -153,7 +155,6 @@ func main() {
 
 	reg := prometheus.NewRegistry()
 	m := registerMetrics(reg)
-	ctx := context.Background()
 
 	var g run.Group
 	{
@@ -168,6 +169,7 @@ func main() {
 			close(sig)
 		})
 	}
+	// Schedule HTTP server
 	{
 		logger := log.With(l, "component", "http")
 		router := http.NewServeMux()
@@ -192,70 +194,11 @@ func main() {
 			}
 		})
 	}
-	{
-		l := log.With(l, "component", "writer")
-		t := time.NewTicker(opts.Period)
-		ctx, cancel := context.WithCancel(ctx)
 
-		g.Add(func() error {
-			level.Info(l).Log("msg", "starting the remote-write client")
-			for {
-				select {
-				case <-t.C:
-					if err := write(ctx, opts.WriteEndpoint, opts.Token, generate(opts.Labels), l); err != nil {
-						m.remoteWriteRequests.WithLabelValues("error").Inc()
-						level.Error(l).Log("msg", "failed to make request", "err", err)
-					} else {
-						m.remoteWriteRequests.WithLabelValues("success").Inc()
-					}
-				case <-ctx.Done():
-					return reportResults(l, m.remoteWriteRequests, opts.SuccessThreshold)
-				}
-			}
-		}, func(_ error) {
-			t.Stop()
-			cancel()
-		})
-	}
+	scheduleWriter(g, opts, l, m)
 
 	if opts.ReadEndpoint != nil {
-		l := log.With(l, "component", "reader")
-		t := time.NewTicker(opts.Period)
-
-		var cancel func()
-		if opts.Duration != 0 {
-			ctx, cancel = context.WithTimeout(ctx, opts.Duration)
-		} else {
-			ctx, cancel = context.WithCancel(ctx)
-		}
-
-		g.Add(func() error {
-			level.Info(l).Log("msg", "waiting for initial delay before querying for metrics")
-			// Wait for at least one period before start reading metrics.
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-time.After(opts.InitialQueryDelay + opts.Period):
-			}
-
-			level.Info(l).Log("msg", "start querying for metrics")
-			for {
-				select {
-				case <-t.C:
-					if err := read(ctx, opts.ReadEndpoint, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m); err != nil {
-						m.queryResponses.WithLabelValues("error").Inc()
-						level.Error(l).Log("msg", "failed to query", "err", err)
-					} else {
-						m.queryResponses.WithLabelValues("success").Inc()
-					}
-				case <-ctx.Done():
-					return reportResults(l, m.queryResponses, opts.SuccessThreshold)
-				}
-			}
-		}, func(_ error) {
-			t.Stop()
-			cancel()
-		})
+		scheduleReader(g, opts, l, m)
 	}
 
 	if err := g.Run(); err != nil {
@@ -264,6 +207,99 @@ func main() {
 	}
 
 	level.Info(l).Log("msg", "up completed its mission!")
+}
+
+func scheduleReader(g run.Group, opts options, logger log.Logger, m metrics) {
+	l := log.With(logger, "component", "reader")
+	t := time.NewTicker(opts.Period)
+
+	var (
+		ctx    = context.Background()
+		cancel context.CancelFunc
+	)
+
+	if opts.Duration != 0 {
+		ctx, cancel = context.WithTimeout(ctx, opts.Duration)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+
+	g.Add(func() error {
+		level.Info(l).Log("msg", "starting the reader")
+		level.Info(l).Log("msg", "waiting for initial delay before querying for metrics")
+		// Wait for at least one period before start reading metrics.
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(opts.InitialQueryDelay + opts.Period):
+		}
+		var (
+			rCtx    context.Context
+			rCancel context.CancelFunc
+		)
+		level.Info(l).Log("msg", "start querying for metrics")
+		for {
+			rCtx, rCancel = context.WithCancel(context.Background())
+			select {
+			case <-t.C:
+				if err := read(rCtx, opts.ReadEndpoint, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m); err != nil {
+					m.queryResponses.WithLabelValues("error").Inc()
+					level.Error(l).Log("msg", "failed to query", "err", err)
+				} else {
+					m.queryResponses.WithLabelValues("success").Inc()
+				}
+				rCancel()
+			case <-ctx.Done():
+				select {
+				case <-rCtx.Done():
+				case <-time.After(gracefulStopDuration):
+				}
+				rCancel()
+				return reportResults(l, m.queryResponses, opts.SuccessThreshold)
+			}
+		}
+	}, func(_ error) {
+		t.Stop()
+		cancel()
+	})
+}
+
+func scheduleWriter(g run.Group, opts options, logger log.Logger, m metrics) {
+	l := log.With(logger, "component", "writer")
+	t := time.NewTicker(opts.Period)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	g.Add(func() error {
+		level.Info(l).Log("msg", "starting the writer")
+		var (
+			wCtx    context.Context
+			wCancel context.CancelFunc
+		)
+		for {
+			wCtx, wCancel = context.WithCancel(context.Background())
+			select {
+			case <-t.C:
+				if err := write(wCtx, opts.WriteEndpoint, opts.Token, generate(opts.Labels), l); err != nil {
+					m.remoteWriteRequests.WithLabelValues("error").Inc()
+					level.Error(l).Log("msg", "failed to make request", "err", err)
+				} else {
+					m.remoteWriteRequests.WithLabelValues("success").Inc()
+				}
+				wCancel()
+			case <-ctx.Done():
+				level.Info(l).Log("msg", "gracefully stopping writer")
+				select {
+				case <-wCtx.Done():
+				case <-time.After(gracefulStopDuration):
+				}
+				wCancel()
+				return reportResults(l, m.remoteWriteRequests, opts.SuccessThreshold)
+			}
+		}
+	}, func(_ error) {
+		t.Stop()
+		cancel()
+	})
 }
 
 func registerMetrics(reg *prometheus.Registry) metrics {

--- a/main.go
+++ b/main.go
@@ -448,7 +448,7 @@ func parseFlags() (options, error) {
 	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
 	flag.StringVar(&opts.Token, "token", "", "The bearer token to set in the authorization header on remote-write requests.")
 	flag.DurationVar(&opts.Period, "period", 5*time.Second, "The time to wait between remote-write requests.")
-	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute, "The duration of the up command to runPeriodically until it stops.")
+	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute, "The duration of the up command to run until it stops.")
 	flag.Float64Var(&opts.SuccessThreshold, "threshold", 0.9, "The percentage of successful requests needed to succeed overall. 0 - 1.")
 	flag.DurationVar(&opts.Latency, "latency", 15*time.Second, "The maximum allowable latency between writing and reading.")
 	flag.DurationVar(&opts.InitialQueryDelay, "initial-query-delay", 5*time.Second, "The time to wait before executing the first query.")

--- a/main.go
+++ b/main.go
@@ -311,7 +311,7 @@ func parseFlags() (options, error) {
 	flag.StringVar(&rawLogLevel, "log.level", "info", "The log filtering level. Options: 'error', 'warn', 'info', 'debug'.")
 	flag.StringVar(&rawWriteEndpoint, "endpoint-write", "", "The endpoint to which to make remote-write requests.")
 	flag.StringVar(&rawReadEndpoint, "endpoint-read", "", "The endpoint to which to make query requests.")
-	flag.Var(&opts.Labels, "labels", "The labels additionally to '__name__' that should be applied to remote-write requests.")
+	flag.Var(&opts.Labels, "labels", "The labels in addition to '__name__' that should be applied to remote-write requests.")
 	flag.StringVar(&opts.Listen, "listen", ":8080", "The address on which internal server runs.")
 	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
 	flag.StringVar(&opts.Token, "token", "", "The bearer token to set in the authorization header on remote-write requests.")


### PR DESCRIPTION
This PR attempts to shift the metric query execution window to gather more accurate results.

To achieve this, it introduces a new CLI arg called, `initial-query-delay` and calculates query execution interval accordingly.

It also:
* Introduces `golangci-lint` (Sorry for noisy changes)
* Changes read path to support any Prometheus query compatible API.
* Reports for the write stats as well.
* Makes sure in-flight requests are not stopped pre-maturily.