### PR TITLE
main.go: Add sleep statements in endless loops

### DIFF
--- a/main.go
+++ b/main.go
@@ -319,7 +319,9 @@ func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opt
 						}
 						m.customQueryExecuted.WithLabelValues(q.Name).Inc()
 					}
+					time.Sleep(100 * time.Millisecond)
 				}
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 	}, func(_ error) {


### PR DESCRIPTION
Previously on errors or empty query configuration the loop would
needlessly loop consuming resources unnecessarily.

@kakkoyun @metalmatze @bwplotka @krasi-georgiev @squat 