### PR TITLE
main.go: add authorization header to read requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Usage of ./up:
   -tls-client-private-key-file string
     	File containing the default x509 private key matching --tls-cert-file. Leave blank to disable TLS.
   -token string
-    	The bearer token to set in the authorization header on remote-write requests. Takes predence over --token-file if set.
+    	The bearer token to set in the authorization header on requests. Takes predence over --token-file if set.
   -token-file string
-    	The file to read a bearer token from and set in the authorization header on remote-write requests.
+    	The file from which to read a bearer token to set in the authorization header on requests.
 ```

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func main() {
 			level.Info(l).Log("msg", "start querying for metrics")
 
 			return runPeriodically(ctx, opts, m.queryResponses, l, ch, func(rCtx context.Context) {
-				if err := read(rCtx, opts.ReadEndpoint, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m, l, opts.tls); err != nil {
+				if err := read(rCtx, opts.ReadEndpoint, opts.Token, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m, l, opts.tls); err != nil {
 					m.queryResponses.WithLabelValues("error").Inc()
 					level.Error(l).Log("msg", "failed to query", "err", err)
 				} else {
@@ -377,9 +377,9 @@ func parseFlags(l log.Logger) (options, error) {
 	flag.StringVar(&opts.Listen, "listen", ":8080", "The address on which internal server runs.")
 	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
 	flag.StringVar(&token, "token", "",
-		"The bearer token to set in the authorization header on remote-write requests. Takes predence over --token-file if set.")
+		"The bearer token to set in the authorization header on requests. Takes predence over --token-file if set.")
 	flag.StringVar(&tokenFile, "token-file", "",
-		"The file to read a bearer token from and set in the authorization header on remote-write requests.")
+		"The file from which to read a bearer token to set in the authorization header on requests.")
 	flag.StringVar(&queriesFileName, "queries-file", "", "A file containing queries to run against the read endpoint.")
 	flag.DurationVar(&opts.Period, "period", 5*time.Second, "The time to wait between remote-write requests.")
 	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute,

--- a/read.go
+++ b/read.go
@@ -63,6 +63,7 @@ func (qr *queryResult) UnmarshalJSON(b []byte) error {
 func read(
 	ctx context.Context,
 	endpoint *url.URL,
+	tp TokenProvider,
 	labels []prompb.Label,
 	ago, latency time.Duration,
 	m metrics,
@@ -79,8 +80,10 @@ func read(
 		if err != nil {
 			return errors.Wrap(err, "create round tripper")
 		}
+
+		rt = newInstantQueryRoundTripper(l, tp, rt)
 	} else {
-		rt = http.DefaultTransport
+		rt = newInstantQueryRoundTripper(l, tp, nil)
 	}
 
 	client, err := promapi.NewClient(promapi.Config{


### PR DESCRIPTION
Previously, the authorization header with the specified bearer token was
only set on remote-write requests and custom query requests. Now, with
the new authenticated Observatorium API, we want to test reading data
from an authenticated read API as well.
This commit ensures that the specified token is set on read requests.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @metalmatze @brancz 

We need this to for tests to pass in https://github.com/observatorium/observatorium/pull/41