### PR TITLE
Support testing Loki read and write requests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ steps:
   pull: always
   image: golang:1.13
   commands:
-  - go build -v
+  - go build -v ./cmd/up
   environment:
     CGO_ENABLED: 0
     GO111MODULE: on

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,7 @@ steps:
   pull: always
   image: golang:1.13
   commands:
+  - apt-get update && apt-get install unzip
   - go test -v -race ./...
   - make test-integration
   environment:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ BIN_DIR ?= ./tmp/bin
 EMBEDMD ?= $(BIN_DIR)/embedmd
 THANOS=$(BIN_DIR)/thanos
 
+LOKI ?= $(BIN_DIR)/loki
+LOKI_VERSION ?= 1.5.0
+
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 GOLANGCILINT ?= $(FIRST_GOPATH)/bin/golangci-lint
 GOLANGCILINT_VERSION ?= v1.21.0
@@ -48,7 +51,7 @@ README.md: $(EMBEDMD) tmp/help.txt
 	$(EMBEDMD) -w README.md
 
 .PHONY: test-integration
-test-integration: build test/integration.sh | $(THANOS)
+test-integration: build test/integration.sh | $(THANOS) $(LOKI)
 	PATH=$$PATH:$$(pwd)/$(BIN_DIR) ./test/integration.sh
 
 $(BIN_DIR):
@@ -61,6 +64,13 @@ $(THANOS): $(BIN_DIR)
 	wget -O ./tmp/thanos.tar.gz https://github.com/thanos-io/thanos/releases/download/v0.11.0/thanos-0.11.0.linux-amd64.tar.gz
 	tar xvfz ./tmp/thanos.tar.gz -C ./tmp
 	mv ./tmp/thanos-0.11.0.linux-amd64/thanos $@
+
+$(LOKI): $(BIN_DIR)
+	loki_pkg="loki-$$(go env GOOS)-$$(go env GOARCH)" && \
+	cd $(BIN_DIR) && curl -O -L "https://github.com/grafana/loki/releases/download/v$(LOKI_VERSION)/$$loki_pkg.zip" && \
+	unzip $$loki_pkg.zip && \
+	mv $$loki_pkg loki && \
+	rm $$loki_pkg.zip
 
 $(GOLANGCILINT):
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCILINT_VERSION)/install.sh \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: up
 
 .PHONY: up
 up:
-	CGO_ENABLED=0 go build -v -ldflags '-w -extldflags '-static''
+	CGO_ENABLED=0 go build -v -ldflags '-w -extldflags '-static'' ./cmd/up
 
 .PHONY: vendor
 vendor: go.mod go.sum

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # UP
 
-UP is a simple client for testing Prometheus remote-write requests.
-The client writes the specified metric at a chosen interval, where the value of the metric is always the current timestamp in milliseconds.
+UP is a simple client for testing Prometheus remote-write and Loki write requests.
+
+For a specified metric the client writes the metric at a chosen interval, where the value of the metric is always the current timestamp in milliseconds. 
+
 It can also read the metric back from a specified endpoint and compare its value against the current time to determine the total write-read latency.
+
+For a specified log entry the client writes the log entry at a chosen interval for the value given. 
+
+It can also read the log back from a specified endpoint and compare the number of results.
+
 When the given duration is greater than 0s, UP will evaluate number of errors and will exit with a non-zero code if the ratio is greater than the specified threshold.
 
 [![Build Status](https://cloud.drone.io/api/badges/observatorium/up/status.svg)](https://cloud.drone.io/observatorium/up)
@@ -32,6 +39,8 @@ Usage of ./up:
     	The duration of the up command to run until it stops. If 0 it will not stop until the process is terminated. (default 5m0s)
   -endpoint-read string
     	The endpoint to which to make query requests.
+  -endpoint-type string
+    	The endpoint type. Options: 'logs', 'metrics'.
   -endpoint-write string
     	The endpoint to which to make remote-write requests.
   -initial-query-delay duration
@@ -44,6 +53,8 @@ Usage of ./up:
     	The address on which internal server runs. (default ":8080")
   -log.level string
     	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
+  -logs value
+    	The logs that should be sent to remote-write requests.
   -name string
     	The name of the metric to send in remote-write requests. (default "up")
   -period duration

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -14,20 +14,28 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/observatorium/up/pkg/auth"
+	"github.com/observatorium/up/pkg/instr"
+	"github.com/observatorium/up/pkg/logs"
 	"github.com/observatorium/up/pkg/metrics"
 	"github.com/observatorium/up/pkg/options"
-	"github.com/observatorium/up/pkg/util"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/oklog/run"
 	"github.com/pkg/errors"
+	promapiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/parser"
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	numOfEndpoints        = 2
+	timeoutBetweenQueries = 100 * time.Millisecond
 )
 
 type queriesFile struct {
@@ -49,10 +57,10 @@ func main() {
 	l = log.WithPrefix(l, "caller", log.DefaultCaller)
 
 	reg := prometheus.NewRegistry()
-	m := util.RegisterMetrics(reg)
+	m := instr.RegisterMetrics(reg)
 
 	// Error channel to gather failures
-	ch := make(chan error, 2)
+	ch := make(chan error, numOfEndpoints)
 
 	g := &run.Group{}
 	{
@@ -85,7 +93,7 @@ func main() {
 			level.Info(l).Log("msg", "starting the writer")
 
 			return runPeriodically(ctx, opts, m.RemoteWriteRequests, l, ch, func(rCtx context.Context) {
-				if err := metrics.Write(rCtx, opts.WriteEndpoint, opts.Token, metrics.Generate(opts.Labels), l, opts.TLS); err != nil {
+				if err := write(rCtx, l, opts); err != nil {
 					m.RemoteWriteRequests.WithLabelValues("error").Inc()
 					level.Error(l).Log("msg", "failed to make request", "err", err)
 				} else {
@@ -103,17 +111,17 @@ func main() {
 			level.Info(l).Log("msg", "starting the reader")
 
 			// Wait for at least one period before start reading metrics.
-			level.Info(l).Log("msg", "waiting for initial delay before querying for metrics")
+			level.Info(l).Log("msg", "waiting for initial delay before querying", "type", opts.EndpointType)
 			select {
 			case <-ctx.Done():
 				return nil
 			case <-time.After(opts.InitialQueryDelay):
 			}
 
-			level.Info(l).Log("msg", "start querying for metrics")
+			level.Info(l).Log("msg", "start querying", "type", opts.EndpointType)
 
 			return runPeriodically(ctx, opts, m.QueryResponses, l, ch, func(rCtx context.Context) {
-				if err := metrics.Read(rCtx, opts.ReadEndpoint, opts.Token, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m, l, opts.TLS); err != nil {
+				if err := read(rCtx, l, m, opts); err != nil {
 					m.QueryResponses.WithLabelValues("error").Inc()
 					level.Error(l).Log("msg", "failed to query", "err", err)
 				} else {
@@ -150,7 +158,40 @@ func main() {
 	level.Info(l).Log("msg", "up completed its mission!")
 }
 
-func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opts options.Options, m util.Metrics, cancel func()) {
+func write(ctx context.Context, l log.Logger, opts options.Options) error {
+	switch opts.EndpointType {
+	case options.MetricsEndpointType:
+		return metrics.Write(ctx, opts.WriteEndpoint, opts.Token, metrics.Generate(opts.Labels), l, opts.TLS)
+	case options.LogsEndpointType:
+		return logs.Write(ctx, opts.WriteEndpoint, opts.Token, logs.Generate(opts.Labels, opts.Logs), l, opts.TLS)
+	}
+
+	return nil
+}
+
+func read(ctx context.Context, l log.Logger, m instr.Metrics, opts options.Options) error {
+	switch opts.EndpointType {
+	case options.MetricsEndpointType:
+		return metrics.Read(ctx, opts.ReadEndpoint, opts.Token, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m, l, opts.TLS)
+	case options.LogsEndpointType:
+		return logs.Read(ctx, opts.ReadEndpoint, opts.Token, opts.Labels, -1*opts.InitialQueryDelay, opts.Latency, m, l, opts.TLS)
+	}
+
+	return nil
+}
+
+func query(ctx context.Context, l log.Logger, q options.QuerySpec, opts options.Options) (promapiv1.Warnings, error) {
+	switch opts.EndpointType {
+	case options.MetricsEndpointType:
+		return metrics.Query(ctx, l, opts.ReadEndpoint, opts.Token, q, opts.TLS)
+	case options.LogsEndpointType:
+		return nil, errors.Errorf("not implemented for logs")
+	}
+
+	return nil, nil
+}
+
+func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opts options.Options, m instr.Metrics, cancel func()) {
 	g.Add(func() error {
 		l := log.With(l, "component", "query-reader")
 		level.Info(l).Log("msg", "starting the reader for queries")
@@ -176,14 +217,7 @@ func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opt
 						return nil
 					default:
 						t := time.Now()
-						warn, err := metrics.Query(
-							ctx,
-							l,
-							opts.ReadEndpoint,
-							opts.Token,
-							q,
-							opts.TLS,
-						)
+						warn, err := query(ctx, l, q, opts)
 						duration := time.Since(t).Seconds()
 						if err != nil {
 							level.Info(l).Log(
@@ -204,9 +238,9 @@ func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opt
 						}
 						m.CustomQueryExecuted.WithLabelValues(q.Name).Inc()
 					}
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(timeoutBetweenQueries)
 				}
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(timeoutBetweenQueries)
 			}
 		}
 	}, func(_ error) {
@@ -253,11 +287,11 @@ func runPeriodically(ctx context.Context, opts options.Options, c *prometheus.Co
 }
 
 func reportResults(l log.Logger, ch chan error, c *prometheus.CounterVec, threshold float64) error {
-	metrics := make(chan prometheus.Metric, 2)
+	metrics := make(chan prometheus.Metric, numOfEndpoints)
 	c.Collect(metrics)
 	close(metrics)
 
-	var success, errors float64
+	var success, failures float64
 
 	for m := range metrics {
 		m1 := &dto.Metric{}
@@ -268,20 +302,20 @@ func reportResults(l log.Logger, ch chan error, c *prometheus.CounterVec, thresh
 		for _, l := range m1.Label {
 			switch *l.Value {
 			case "error":
-				errors = m1.GetCounter().GetValue()
+				failures = m1.GetCounter().GetValue()
 			case "success":
 				success = m1.GetCounter().GetValue()
 			}
 		}
 	}
 
-	level.Info(l).Log("msg", "number of requests", "success", success, "errors", errors)
+	level.Info(l).Log("msg", "number of requests", "success", success, "errors", failures)
 
-	ratio := success / (success + errors)
+	ratio := success / (success + failures)
 	if ratio < threshold {
 		level.Error(l).Log("msg", "ratio is below threshold")
 
-		err := fmt.Errorf("failed with less than %2.f%% success ratio - actual %2.f%%", threshold*100, ratio*100)
+		err := errors.Errorf("failed with less than %2.f%% success ratio - actual %2.f%%", threshold*100, ratio*100) //nolint:gomnd
 		ch <- err
 
 		return err
@@ -294,6 +328,7 @@ func reportResults(l log.Logger, ch chan error, c *prometheus.CounterVec, thresh
 
 func parseFlags(l log.Logger) (options.Options, error) {
 	var (
+		rawEndpointType  string
 		rawWriteEndpoint string
 		rawReadEndpoint  string
 		rawLogLevel      string
@@ -305,22 +340,26 @@ func parseFlags(l log.Logger) (options.Options, error) {
 	opts := options.Options{}
 
 	flag.StringVar(&rawLogLevel, "log.level", "info", "The log filtering level. Options: 'error', 'warn', 'info', 'debug'.")
+	flag.StringVar(&rawEndpointType, "endpoint-type", "", "The endpoint type. Options: 'logs', 'metrics'.")
 	flag.StringVar(&rawWriteEndpoint, "endpoint-write", "", "The endpoint to which to make remote-write requests.")
 	flag.StringVar(&rawReadEndpoint, "endpoint-read", "", "The endpoint to which to make query requests.")
 	flag.Var(&opts.Labels, "labels", "The labels in addition to '__name__' that should be applied to remote-write requests.")
 	flag.StringVar(&opts.Listen, "listen", ":8080", "The address on which internal server runs.")
+	flag.Var(&opts.Logs, "logs", "The logs that should be sent to remote-write requests.")
 	flag.StringVar(&opts.Name, "name", "up", "The name of the metric to send in remote-write requests.")
 	flag.StringVar(&token, "token", "",
 		"The bearer token to set in the authorization header on requests. Takes predence over --token-file if set.")
 	flag.StringVar(&tokenFile, "token-file", "",
 		"The file from which to read a bearer token to set in the authorization header on requests.")
 	flag.StringVar(&queriesFileName, "queries-file", "", "A file containing queries to run against the read endpoint.")
-	flag.DurationVar(&opts.Period, "period", 5*time.Second, "The time to wait between remote-write requests.")
-	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute,
+	flag.DurationVar(&opts.Period, "period", 5*time.Second, "The time to wait between remote-write requests.") //nolint:gomnd
+	flag.DurationVar(&opts.Duration, "duration", 5*time.Minute,                                                //nolint:gomnd
 		"The duration of the up command to run until it stops. If 0 it will not stop until the process is terminated.")
 	flag.Float64Var(&opts.SuccessThreshold, "threshold", 0.9, "The percentage of successful requests needed to succeed overall. 0 - 1.")
-	flag.DurationVar(&opts.Latency, "latency", 15*time.Second, "The maximum allowable latency between writing and reading.")
-	flag.DurationVar(&opts.InitialQueryDelay, "initial-query-delay", 5*time.Second, "The time to wait before executing the first query.")
+	flag.DurationVar(&opts.Latency, "latency", 15*time.Second, //nolint:gomnd
+		"The maximum allowable latency between writing and reading.")
+	flag.DurationVar(&opts.InitialQueryDelay, "initial-query-delay", 5*time.Second, //nolint:gomnd
+		"The time to wait before executing the first query.")
 	flag.StringVar(&opts.TLS.Cert, "tls-client-cert-file", "",
 		"File containing the default x509 Certificate for HTTPS. Leave blank to disable TLS.")
 	flag.StringVar(&opts.TLS.Key, "tls-client-private-key-file", "",
@@ -329,82 +368,43 @@ func parseFlags(l log.Logger) (options.Options, error) {
 		"File containing the TLS CA to use against servers for verification. If no CA is specified, there won't be any verification.")
 	flag.Parse()
 
-	return buildOptionsFromFlags(l, opts, rawLogLevel, rawWriteEndpoint, rawReadEndpoint, queriesFileName, token, tokenFile)
+	return buildOptionsFromFlags(l, opts, rawLogLevel, rawEndpointType, rawWriteEndpoint, rawReadEndpoint, queriesFileName, token, tokenFile)
 }
 
 func buildOptionsFromFlags(
 	l log.Logger,
 	opts options.Options,
-	rawLogLevel, rawWriteEndpoint, rawReadEndpoint, queriesFileName, token, tokenFile string,
+	rawLogLevel, rawEndpointType, rawWriteEndpoint, rawReadEndpoint, queriesFileName, token, tokenFile string,
 ) (options.Options, error) {
 	var err error
 
-	switch rawLogLevel {
-	case "error":
-		opts.LogLevel = level.AllowError()
-	case "warn":
-		opts.LogLevel = level.AllowWarn()
-	case "info":
-		opts.LogLevel = level.AllowInfo()
-	case "debug":
-		opts.LogLevel = level.AllowDebug()
-	default:
-		panic("unexpected log level")
+	err = parseLogLevel(&opts, rawLogLevel)
+	if err != nil {
+		return opts, errors.Wrap(err, "parsing log level")
 	}
 
-	if rawWriteEndpoint != "" {
-		writeEndpoint, err := url.ParseRequestURI(rawWriteEndpoint)
-		if err != nil {
-			return opts, fmt.Errorf("--endpoint-write is invalid: %w", err)
-		}
-
-		opts.WriteEndpoint = writeEndpoint
-	} else {
-		l.Log("msg", "no write endpoint specified, no write tests being performed")
+	err = parseEndpointType(&opts, rawEndpointType)
+	if err != nil {
+		return opts, errors.Wrap(err, "parsing endpoint type")
 	}
 
-	if rawReadEndpoint != "" {
-		var readEndpoint *url.URL
-		if rawReadEndpoint != "" {
-			readEndpoint, err = url.ParseRequestURI(rawReadEndpoint)
-			if err != nil {
-				return opts, fmt.Errorf("--endpoint-read is invalid: %w", err)
-			}
-		}
-
-		opts.ReadEndpoint = readEndpoint
-	} else {
-		l.Log("msg", "no read endpoint specified, no read tests being performed")
+	err = parseWriteEndpoint(&opts, l, rawWriteEndpoint)
+	if err != nil {
+		return opts, errors.Wrap(err, "parsing write endpoint")
 	}
 
-	if queriesFileName != "" {
-		b, err := ioutil.ReadFile(queriesFileName)
-		if err != nil {
-			return opts, fmt.Errorf("--queries-file is invalid: %w", err)
-		}
+	err = parseReadEndpoint(&opts, l, rawReadEndpoint)
+	if err != nil {
+		return opts, errors.Wrap(err, "parsing read endpoint")
+	}
 
-		qf := queriesFile{}
-		err = yaml.Unmarshal(b, &qf)
-
-		if err != nil {
-			return opts, fmt.Errorf("--queries-file content is invalid: %w", err)
-		}
-
-		l.Log("msg", fmt.Sprintf("%d queries configured to be queried periodically", len(qf.Queries)))
-
-		// validate queries
-		for _, q := range qf.Queries {
-			_, err = parser.ParseExpr(q.Query)
-			if err != nil {
-				return opts, fmt.Errorf("query %q in --queries-file content is invalid: %w", q.Name, err)
-			}
-		}
-
-		opts.Queries = qf.Queries
+	err = parseQueriesFileName(&opts, l, queriesFileName)
+	if err != nil {
+		return opts, errors.Wrap(err, "parsing queries file name")
 	}
 
 	if opts.Latency <= opts.Period {
-		return opts, errors.New("--latency cannot be less than period")
+		return opts, errors.Errorf("--latency cannot be less than period")
 	}
 
 	opts.Labels = append(opts.Labels, prompb.Label{
@@ -415,6 +415,96 @@ func buildOptionsFromFlags(
 	opts.Token = tokenProvider(token, tokenFile)
 
 	return opts, err
+}
+
+func parseLogLevel(opts *options.Options, rawLogLevel string) error {
+	switch rawLogLevel {
+	case "error":
+		opts.LogLevel = level.AllowError()
+	case "warn":
+		opts.LogLevel = level.AllowWarn()
+	case "info":
+		opts.LogLevel = level.AllowInfo()
+	case "debug":
+		opts.LogLevel = level.AllowDebug()
+	default:
+		return errors.Errorf("unexpected log level")
+	}
+
+	return nil
+}
+
+func parseEndpointType(opts *options.Options, rawEndpointType string) error {
+	switch options.EndpointType(rawEndpointType) {
+	case options.LogsEndpointType:
+		opts.EndpointType = options.LogsEndpointType
+	case options.MetricsEndpointType:
+		opts.EndpointType = options.MetricsEndpointType
+	default:
+		return errors.Errorf("unexpected endpoint type")
+	}
+
+	return nil
+}
+
+func parseWriteEndpoint(opts *options.Options, l log.Logger, rawWriteEndpoint string) error {
+	if rawWriteEndpoint != "" {
+		writeEndpoint, err := url.ParseRequestURI(rawWriteEndpoint)
+		if err != nil {
+			return fmt.Errorf("--endpoint-write is invalid: %w", err)
+		}
+
+		opts.WriteEndpoint = writeEndpoint
+	} else {
+		l.Log("msg", "no write endpoint specified, no write tests being performed")
+	}
+
+	return nil
+}
+
+func parseReadEndpoint(opts *options.Options, l log.Logger, rawReadEndpoint string) error {
+	if rawReadEndpoint != "" {
+		readEndpoint, err := url.ParseRequestURI(rawReadEndpoint)
+		if err != nil {
+			return fmt.Errorf("--endpoint-read is invalid: %w", err)
+		}
+
+		opts.ReadEndpoint = readEndpoint
+	} else {
+		l.Log("msg", "no read endpoint specified, no read tests being performed")
+	}
+
+	return nil
+}
+
+func parseQueriesFileName(opts *options.Options, l log.Logger, queriesFileName string) error {
+	if queriesFileName != "" {
+		b, err := ioutil.ReadFile(queriesFileName)
+		if err != nil {
+			return fmt.Errorf("--queries-file is invalid: %w", err)
+		}
+
+		qf := queriesFile{}
+		err = yaml.Unmarshal(b, &qf)
+
+		if err != nil {
+			return fmt.Errorf("--queries-file content is invalid: %w", err)
+		}
+
+		l.Log("msg", fmt.Sprintf("%d queries configured to be queried periodically", len(qf.Queries)))
+
+		// validate queries
+		for _, q := range qf.Queries {
+			_, err = parser.ParseExpr(q.Query)
+			if err != nil {
+				return fmt.Errorf("query %q in --queries-file content is invalid: %w", q.Name, err)
+			}
+		}
+
+		opts.Queries = qf.Queries
+	}
+
+	return nil
 }
 
 func tokenProvider(token, tokenFile string) auth.TokenProvider {
@@ -444,7 +534,7 @@ func scheduleHTTPServer(l log.Logger, opts options.Options, reg *prometheus.Regi
 		level.Info(logger).Log("msg", "starting the HTTP server", "address", opts.Listen)
 		return srv.ListenAndServe()
 	}, func(err error) {
-		if err == http.ErrServerClosed {
+		if errors.Is(err, http.ErrServerClosed) {
 			level.Warn(logger).Log("msg", "internal server closed unexpectedly")
 			return
 		}

--- a/pkg/auth/doc.go
+++ b/pkg/auth/doc.go
@@ -1,0 +1,2 @@
+// Package auth provides the token and roundtripper for bearer based authentication.
+package auth

--- a/pkg/auth/roundtripper.go
+++ b/pkg/auth/roundtripper.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/go-kit/kit/log"
+)
+
+type BearerTokenRoundTripper struct {
+	l       log.Logger
+	r       http.RoundTripper
+	t       TokenProvider
+	TraceID string
+}
+
+func NewBearerTokenRoundTripper(l log.Logger, t TokenProvider, r http.RoundTripper) *BearerTokenRoundTripper {
+	if r == nil {
+		r = http.DefaultTransport
+	}
+
+	return &BearerTokenRoundTripper{
+		l: l,
+		t: t,
+		r: r,
+	}
+}
+
+func (r *BearerTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := r.t.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	if token != "" {
+		req.Header.Add("Authorization", "Bearer "+token)
+	}
+
+	resp, err := r.r.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	r.TraceID = resp.Header.Get("X-Thanos-Trace-Id")
+
+	return resp, err
+}

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,9 +1,13 @@
-package main
+package auth
 
 import (
 	"io/ioutil"
 	"strings"
 )
+
+type TokenProvider interface {
+	Get() (string, error)
+}
 
 func NewNoOpTokenProvider() *StaticToken {
 	return &StaticToken{token: ""}

--- a/pkg/instr/doc.go
+++ b/pkg/instr/doc.go
@@ -1,0 +1,2 @@
+// Package instr provides the instrumentation facility for metrics.
+package instr

--- a/pkg/instr/metrics.go
+++ b/pkg/instr/metrics.go
@@ -1,4 +1,4 @@
-package util
+package instr
 
 import "github.com/prometheus/client_golang/prometheus"
 
@@ -24,7 +24,7 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 		MetricValueDifference: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "up_metric_value_difference",
 			Help:    "The time difference between the current timestamp and the timestamp in the metrics value.",
-			Buckets: prometheus.LinearBuckets(4, 0.25, 16),
+			Buckets: prometheus.LinearBuckets(4, 0.25, 16), //nolint:gomnd
 		}),
 		CustomQueryExecuted: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "up_custom_query_executed_total",

--- a/pkg/logs/doc.go
+++ b/pkg/logs/doc.go
@@ -1,0 +1,3 @@
+// Package logs represents the reader and writer interface
+// to query and push logs to Loki for a set of labels.
+package logs

--- a/pkg/logs/read.go
+++ b/pkg/logs/read.go
@@ -1,0 +1,98 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/observatorium/up/pkg/auth"
+	"github.com/observatorium/up/pkg/instr"
+	"github.com/observatorium/up/pkg/options"
+	"github.com/observatorium/up/pkg/transport"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+// Read executes query against Loki with the same labels to retrieve the written logs back.
+func Read(
+	ctx context.Context,
+	endpoint *url.URL,
+	tp auth.TokenProvider,
+	labels []prompb.Label, // change to Loki ProtoBufs
+	ago, latency time.Duration,
+	m instr.Metrics,
+	l log.Logger,
+	tls options.TLS,
+) error {
+	var (
+		rt  http.RoundTripper
+		err error
+	)
+
+	if endpoint.Scheme == transport.HTTPS {
+		rt, err = transport.NewTLSTransport(l, tls)
+		if err != nil {
+			return errors.Wrap(err, "create round tripper")
+		}
+
+		rt = auth.NewBearerTokenRoundTripper(l, tp, rt)
+	} else {
+		rt = auth.NewBearerTokenRoundTripper(l, tp, nil)
+	}
+
+	client := &http.Client{Transport: rt}
+
+	labelSelectors := make([]string, len(labels))
+	for i, label := range labels {
+		labelSelectors[i] = fmt.Sprintf(`%s="%s"`, label.Name, label.Value)
+	}
+
+	query := fmt.Sprintf("{%s}", strings.Join(labelSelectors, ","))
+
+	params := url.Values{}
+	params.Add("query", query)
+	endpoint.RawQuery = params.Encode()
+
+	req, err := http.NewRequest("Get", endpoint.String(), nil)
+	if err != nil {
+		return errors.Wrap(err, "creating request")
+	}
+
+	res, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return errors.Wrap(err, "making request")
+	}
+
+	if res.StatusCode != http.StatusOK {
+		err = errors.Errorf(res.Status)
+		return errors.Wrap(err, "non-200 status")
+	}
+
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return errors.Wrap(err, "reading response body")
+	}
+
+	rr := &queryResponse{}
+
+	err = json.Unmarshal(body, rr)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling response")
+	}
+
+	rl := len(rr.Data.Result)
+	if rl != 1 {
+		return errors.Errorf("expected one log entry, got %d", rl)
+	}
+
+	return nil
+}

--- a/pkg/logs/types.go
+++ b/pkg/logs/types.go
@@ -1,0 +1,19 @@
+package logs
+
+type queryResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string   `json:"resultType"`
+		Result     []stream `json:"result"`
+	} `json:"data"`
+}
+
+// PushRequest reprents the payload to push logs to Loki.
+type PushRequest struct {
+	Streams []stream `json:"streams"`
+}
+
+type stream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string        `json:"values"`
+}

--- a/pkg/logs/write.go
+++ b/pkg/logs/write.go
@@ -1,0 +1,84 @@
+package logs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/observatorium/up/pkg/auth"
+	"github.com/observatorium/up/pkg/options"
+	"github.com/observatorium/up/pkg/transport"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+// Write executes a push against Loki sending a set of labels and log entries to store.
+func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq *PushRequest, l log.Logger, tls options.TLS) error {
+	var (
+		buf []byte
+		err error
+		req *http.Request
+		res *http.Response
+		rt  http.RoundTripper
+	)
+
+	if endpoint.Scheme == transport.HTTPS {
+		rt, err = transport.NewTLSTransport(l, tls)
+		if err != nil {
+			return errors.Wrap(err, "create round tripper")
+		}
+
+		rt = auth.NewBearerTokenRoundTripper(l, t, rt)
+	} else {
+		rt = auth.NewBearerTokenRoundTripper(l, t, nil)
+	}
+
+	client := &http.Client{Transport: rt}
+
+	buf, err = json.Marshal(wreq)
+	if err != nil {
+		return errors.Wrap(err, "marshalling payload")
+	}
+
+	req, err = http.NewRequest("POST", endpoint.String(), bytes.NewBuffer(buf))
+	if err != nil {
+		return errors.Wrap(err, "creating request")
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err = client.Do(req.WithContext(ctx)) //nolint:bodyclose
+	if err != nil {
+		return errors.Wrap(err, "making request")
+	}
+
+	defer transport.ExhaustCloseWithLogOnErr(l, res.Body)
+
+	if res.StatusCode != http.StatusNoContent {
+		err = errors.Errorf(res.Status)
+		return errors.Wrap(err, "non-204 status")
+	}
+
+	return nil
+}
+
+// Generate takes a set of labels and log lines and returns the payload to push logs to Loki.
+func Generate(labels []prompb.Label, values [][]string) *PushRequest {
+	s := make(map[string]string)
+	for _, label := range labels {
+		s[label.Name] = label.Value
+	}
+
+	return &PushRequest{
+		Streams: []stream{
+			{
+				Stream: s,
+				Values: values,
+			},
+		},
+	}
+}

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -1,0 +1,3 @@
+// Package metrics represents the reader and writer interface
+// to remote write to and query from Prometheus for a set of labels.
+package metrics

--- a/pkg/metrics/write.go
+++ b/pkg/metrics/write.go
@@ -1,4 +1,4 @@
-package main
+package metrics
 
 import (
 	"bytes"
@@ -10,11 +10,15 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/observatorium/up/pkg/auth"
+	"github.com/observatorium/up/pkg/options"
+	"github.com/observatorium/up/pkg/transport"
+	"github.com/observatorium/up/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 )
 
-func write(ctx context.Context, endpoint *url.URL, t TokenProvider, wreq proto.Message, l log.Logger, tls tlsOptions) error {
+func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq proto.Message, l log.Logger, tls options.TLS) error {
 	var (
 		buf []byte
 		err error
@@ -23,8 +27,8 @@ func write(ctx context.Context, endpoint *url.URL, t TokenProvider, wreq proto.M
 		rt  http.RoundTripper
 	)
 
-	if endpoint.Scheme == https {
-		rt, err = newTLSTransport(l, tls)
+	if endpoint.Scheme == transport.HTTPS {
+		rt, err = transport.NewTLSTransport(l, tls)
 		if err != nil {
 			return errors.Wrap(err, "create round tripper")
 		}
@@ -58,7 +62,7 @@ func write(ctx context.Context, endpoint *url.URL, t TokenProvider, wreq proto.M
 		return errors.Wrap(err, "making request")
 	}
 
-	defer exhaustCloseWithLogOnErr(l, res.Body)
+	defer util.ExhaustCloseWithLogOnErr(l, res.Body)
 
 	if res.StatusCode != http.StatusOK {
 		err = errors.New(res.Status)
@@ -68,7 +72,7 @@ func write(ctx context.Context, endpoint *url.URL, t TokenProvider, wreq proto.M
 	return nil
 }
 
-func generate(labels []prompb.Label) *prompb.WriteRequest {
+func Generate(labels []prompb.Label) *prompb.WriteRequest {
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 
 	return &prompb.WriteRequest{

--- a/pkg/metrics/write.go
+++ b/pkg/metrics/write.go
@@ -7,17 +7,18 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/gogo/protobuf/proto"
-	"github.com/golang/snappy"
 	"github.com/observatorium/up/pkg/auth"
 	"github.com/observatorium/up/pkg/options"
 	"github.com/observatorium/up/pkg/transport"
-	"github.com/observatorium/up/pkg/util"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 )
 
+// Write executes a remote-write against Prometheus sending a set of labels and metrics to store.
 func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq proto.Message, l log.Logger, tls options.TLS) error {
 	var (
 		buf []byte
@@ -62,16 +63,17 @@ func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq pr
 		return errors.Wrap(err, "making request")
 	}
 
-	defer util.ExhaustCloseWithLogOnErr(l, res.Body)
+	defer transport.ExhaustCloseWithLogOnErr(l, res.Body)
 
 	if res.StatusCode != http.StatusOK {
-		err = errors.New(res.Status)
+		err = errors.Errorf(res.Status)
 		return errors.Wrap(err, "non-200 status")
 	}
 
 	return nil
 }
 
+// Generate takes a set of labels and metrics key-value pairs and returns the payload to write metrics to Prometheus.
 func Generate(labels []prompb.Label) *prompb.WriteRequest {
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 

--- a/pkg/options/doc.go
+++ b/pkg/options/doc.go
@@ -1,0 +1,2 @@
+// Package options handles the command line flags.
+package options

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -1,0 +1,80 @@
+package options
+
+import (
+    "net/url"
+    "strconv"
+    "strings"
+    "time"
+
+    "github.com/go-kit/kit/log/level"
+    "github.com/observatorium/up/pkg/auth"
+    "github.com/pkg/errors"
+    "github.com/prometheus/common/model"
+    "github.com/prometheus/prometheus/prompb"
+)
+
+type TLS struct {
+    Cert   string
+    Key    string
+    CACert string
+}
+
+type Options struct {
+    LogLevel          level.Option
+    WriteEndpoint     *url.URL
+    ReadEndpoint      *url.URL
+    Labels            labelArg
+    Listen            string
+    Name              string
+    Token             auth.TokenProvider
+    Queries           []QuerySpec
+    Period            time.Duration
+    Duration          time.Duration
+    Latency           time.Duration
+    InitialQueryDelay time.Duration
+    SuccessThreshold  float64
+    TLS               TLS
+}
+
+type QuerySpec struct {
+    Name  string `yaml:"name"`
+    Query string `yaml:"query"`
+}
+
+type labelArg []prompb.Label
+
+func (la *labelArg) String() string {
+    ls := make([]string, len(*la))
+    for i, l := range *la {
+        ls[i] = l.Name + "=" + l.Value
+    }
+
+    return strings.Join(ls, ", ")
+}
+
+func (la *labelArg) Set(v string) error {
+    labels := strings.Split(v, ",")
+    lset := make([]prompb.Label, len(labels))
+
+    for i, l := range labels {
+        parts := strings.SplitN(l, "=", 2)
+        if len(parts) != 2 {
+            return errors.Errorf("unrecognized label %q", l)
+        }
+
+        if !model.LabelName.IsValid(model.LabelName(parts[0])) {
+            return errors.Errorf("unsupported format for label %s", l)
+        }
+
+        val, err := strconv.Unquote(parts[1])
+        if err != nil {
+            return errors.Wrap(err, "unquote label value")
+        }
+
+        lset[i] = prompb.Label{Name: parts[0], Value: val}
+    }
+
+    *la = lset
+
+    return nil
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -1,80 +1,122 @@
 package options
 
 import (
-    "net/url"
-    "strconv"
-    "strings"
-    "time"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
 
-    "github.com/go-kit/kit/log/level"
-    "github.com/observatorium/up/pkg/auth"
-    "github.com/pkg/errors"
-    "github.com/prometheus/common/model"
-    "github.com/prometheus/prometheus/prompb"
+	"github.com/go-kit/kit/log/level"
+	"github.com/observatorium/up/pkg/auth"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
 )
 
 type TLS struct {
-    Cert   string
-    Key    string
-    CACert string
+	Cert   string
+	Key    string
+	CACert string
 }
 
 type Options struct {
-    LogLevel          level.Option
-    WriteEndpoint     *url.URL
-    ReadEndpoint      *url.URL
-    Labels            labelArg
-    Listen            string
-    Name              string
-    Token             auth.TokenProvider
-    Queries           []QuerySpec
-    Period            time.Duration
-    Duration          time.Duration
-    Latency           time.Duration
-    InitialQueryDelay time.Duration
-    SuccessThreshold  float64
-    TLS               TLS
+	LogLevel          level.Option
+	EndpointType      EndpointType
+	WriteEndpoint     *url.URL
+	ReadEndpoint      *url.URL
+	Labels            labelArg
+	Logs              logs
+	Listen            string
+	Name              string
+	Token             auth.TokenProvider
+	Queries           []QuerySpec
+	Period            time.Duration
+	Duration          time.Duration
+	Latency           time.Duration
+	InitialQueryDelay time.Duration
+	SuccessThreshold  float64
+	TLS               TLS
 }
 
+type EndpointType string
+
+const (
+	LogsEndpointType    EndpointType = "logs"
+	MetricsEndpointType EndpointType = "metrics"
+)
+
 type QuerySpec struct {
-    Name  string `yaml:"name"`
-    Query string `yaml:"query"`
+	Name  string `yaml:"name"`
+	Query string `yaml:"query"`
 }
 
 type labelArg []prompb.Label
 
 func (la *labelArg) String() string {
-    ls := make([]string, len(*la))
-    for i, l := range *la {
-        ls[i] = l.Name + "=" + l.Value
-    }
+	ls := make([]string, len(*la))
+	for i, l := range *la {
+		ls[i] = l.Name + "=" + l.Value
+	}
 
-    return strings.Join(ls, ", ")
+	return strings.Join(ls, ", ")
 }
 
 func (la *labelArg) Set(v string) error {
-    labels := strings.Split(v, ",")
-    lset := make([]prompb.Label, len(labels))
+	labels := strings.Split(v, ",")
+	lset := make([]prompb.Label, len(labels))
 
-    for i, l := range labels {
-        parts := strings.SplitN(l, "=", 2)
-        if len(parts) != 2 {
-            return errors.Errorf("unrecognized label %q", l)
-        }
+	for i, l := range labels {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) != 2 { //nolint:gomnd
+			return errors.Errorf("unrecognized label %q", l)
+		}
 
-        if !model.LabelName.IsValid(model.LabelName(parts[0])) {
-            return errors.Errorf("unsupported format for label %s", l)
-        }
+		if !model.LabelName.IsValid(model.LabelName(parts[0])) {
+			return errors.Errorf("unsupported format for label %s", l)
+		}
 
-        val, err := strconv.Unquote(parts[1])
-        if err != nil {
-            return errors.Wrap(err, "unquote label value")
-        }
+		val, err := strconv.Unquote(parts[1])
+		if err != nil {
+			return errors.Wrap(err, "unquote label value")
+		}
 
-        lset[i] = prompb.Label{Name: parts[0], Value: val}
-    }
+		lset[i] = prompb.Label{Name: parts[0], Value: val}
+	}
 
-    *la = lset
+	*la = lset
 
-    return nil
+	return nil
+}
+
+type logs [][]string
+
+func (va *logs) String() string {
+	s := make([]string, len(*va))
+
+	for i, l := range *va {
+		s[i] = strings.Join(l, ",")
+	}
+
+	return strings.Join(s, ",")
+}
+
+func (va *logs) Set(v string) error {
+	vas := strings.Split(v, "],[")
+	vset := make(logs, len(vas))
+
+	for i, v := range vas {
+		v = strings.TrimLeft(v, "[")
+		v = strings.TrimRight(v, "]")
+		vs := strings.Split(v, ",")
+
+		for i, s := range vs {
+			vs[i] = strings.Trim(s, `"`)
+		}
+
+		vset[i] = vs
+	}
+
+	*va = vset
+
+	return nil
 }

--- a/pkg/transport/body.go
+++ b/pkg/transport/body.go
@@ -1,10 +1,8 @@
-package util
+package transport
 
 import (
 	"io"
 	"io/ioutil"
-	"strconv"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -19,8 +17,4 @@ func ExhaustCloseWithLogOnErr(l log.Logger, rc io.ReadCloser) {
 	if err := rc.Close(); err != nil {
 		level.Warn(l).Log("msg", "detected close error", "err", errors.Wrap(err, "response body close"))
 	}
-}
-
-func FormatTime(t time.Time) string {
-	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
 }

--- a/pkg/transport/doc.go
+++ b/pkg/transport/doc.go
@@ -1,0 +1,2 @@
+// Package transport provides the transport layer security configuration for logs and metrics endpoints.
+package transport

--- a/pkg/transport/tls.go
+++ b/pkg/transport/tls.go
@@ -1,4 +1,4 @@
-package main
+package transport
 
 import (
 	"crypto/tls"
@@ -9,6 +9,8 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 )
+
+const HTTPS = "https"
 
 func newTLSConfig(logger log.Logger, certFile, keyFile, caCertFile string) (*tls.Config, error) {
 	var certPool *x509.CertPool

--- a/pkg/transport/tls.go
+++ b/pkg/transport/tls.go
@@ -40,7 +40,7 @@ func newTLSConfig(logger log.Logger, certFile, keyFile, caCertFile string) (*tls
 	tlsCfg := &tls.Config{RootCAs: certPool}
 
 	if (keyFile != "") != (certFile != "") {
-		return nil, errors.New("both client key and certificate must be provided")
+		return nil, errors.Errorf("both client key and certificate must be provided")
 	}
 
 	if certFile != "" {

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -1,4 +1,4 @@
-package main
+package transport
 
 import (
 	"net"
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/observatorium/up/pkg/options"
 	"github.com/pkg/errors"
 )
 
-func newTLSTransport(l log.Logger, tls tlsOptions) (*http.Transport, error) {
+func NewTLSTransport(l log.Logger, tls options.TLS) (*http.Transport, error) {
 	tlsConfig, err := newTLSConfig(l, tls.Cert, tls.Key, tls.CACert)
 	if err != nil {
 		return nil, errors.Wrap(err, "tls config")

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -19,14 +19,14 @@ func NewTLSTransport(l log.Logger, tls options.TLS) (*http.Transport, error) {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
+			Timeout:   30 * time.Second, //nolint:gomnd
+			KeepAlive: 30 * time.Second, //nolint:gomnd
 			DualStack: true,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
+		MaxIdleConns:          100,              //nolint:gomnd
+		IdleConnTimeout:       90 * time.Second, //nolint:gomnd
+		TLSHandshakeTimeout:   10 * time.Second, //nolint:gomnd
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig:       tlsConfig,
 	}, nil

--- a/pkg/util/metrics.go
+++ b/pkg/util/metrics.go
@@ -1,40 +1,40 @@
-package main
+package util
 
 import "github.com/prometheus/client_golang/prometheus"
 
-type metrics struct {
-	remoteWriteRequests     *prometheus.CounterVec
-	queryResponses          *prometheus.CounterVec
-	metricValueDifference   prometheus.Histogram
-	customQueryExecuted     *prometheus.CounterVec
-	customQueryErrors       *prometheus.CounterVec
-	customQueryLastDuration *prometheus.GaugeVec
+type Metrics struct {
+	RemoteWriteRequests     *prometheus.CounterVec
+	QueryResponses          *prometheus.CounterVec
+	MetricValueDifference   prometheus.Histogram
+	CustomQueryExecuted     *prometheus.CounterVec
+	CustomQueryErrors       *prometheus.CounterVec
+	CustomQueryLastDuration *prometheus.GaugeVec
 }
 
-func registerMetrics(reg *prometheus.Registry) metrics {
-	m := metrics{
-		remoteWriteRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
+func RegisterMetrics(reg *prometheus.Registry) Metrics {
+	m := Metrics{
+		RemoteWriteRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "up_remote_writes_total",
 			Help: "Total number of remote write requests.",
 		}, []string{"result"}),
-		queryResponses: prometheus.NewCounterVec(prometheus.CounterOpts{
+		QueryResponses: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "up_queries_total",
 			Help: "The total number of queries made.",
 		}, []string{"result"}),
-		metricValueDifference: prometheus.NewHistogram(prometheus.HistogramOpts{
+		MetricValueDifference: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "up_metric_value_difference",
 			Help:    "The time difference between the current timestamp and the timestamp in the metrics value.",
 			Buckets: prometheus.LinearBuckets(4, 0.25, 16),
 		}),
-		customQueryExecuted: prometheus.NewCounterVec(prometheus.CounterOpts{
+		CustomQueryExecuted: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "up_custom_query_executed_total",
 			Help: "The total number of custom specified queries executed.",
 		}, []string{"query"}),
-		customQueryErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+		CustomQueryErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "up_custom_query_errors_total",
 			Help: "The total number of custom specified queries executed.",
 		}, []string{"query"}),
-		customQueryLastDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		CustomQueryLastDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "up_custom_query_last_duration",
 			Help: "The duration of the query execution last time the query was executed successfully.",
 		}, []string{"query"}),
@@ -42,12 +42,12 @@ func registerMetrics(reg *prometheus.Registry) metrics {
 	reg.MustRegister(
 		prometheus.NewGoCollector(),
 		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
-		m.remoteWriteRequests,
-		m.queryResponses,
-		m.metricValueDifference,
-		m.customQueryExecuted,
-		m.customQueryErrors,
-		m.customQueryLastDuration,
+		m.RemoteWriteRequests,
+		m.QueryResponses,
+		m.MetricValueDifference,
+		m.CustomQueryExecuted,
+		m.CustomQueryErrors,
+		m.CustomQueryLastDuration,
 	)
 
 	return m

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import (
 	"io"
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func exhaustCloseWithLogOnErr(l log.Logger, rc io.ReadCloser) {
+func ExhaustCloseWithLogOnErr(l log.Logger, rc io.ReadCloser) {
 	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
 		level.Warn(l).Log("msg", "failed to exhaust reader, performance may be impeded", "err", err)
 	}
@@ -21,6 +21,6 @@ func exhaustCloseWithLogOnErr(l log.Logger, rc io.ReadCloser) {
 	}
 }
 
-func formatTime(t time.Time) string {
+func FormatTime(t time.Time) string {
 	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
 }

--- a/test/config/loki.yml
+++ b/test/config/loki.yml
@@ -1,0 +1,40 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+querier:
+  engine:
+    max_look_back_period: 2h
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 5m
+  chunk_retain_period: 1h
+
+schema_config:
+  configs:
+  - from: 1995-01-01
+    store: boltdb
+    object_store: filesystem
+    schema: v11
+    index:
+      prefix: index_
+      period: 168h
+
+storage_config:
+  boltdb:
+    directory: /tmp/loki/index
+
+  filesystem:
+    directory: /tmp/loki/chunks
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: false


### PR DESCRIPTION
This PR add testing capabilities to `up` for Loki read/write requests. It facilitates the same round trip mechanism of the metrics endpoint. In addition due to go module conflicts between thanos and loki custom types to pass and retrieve payloads to Loki.