### PR TITLE
pkg/logs: fix GET request type

### DIFF
--- a/pkg/logs/read.go
+++ b/pkg/logs/read.go
@@ -60,7 +60,7 @@ func Read(
 	params.Add("query", query)
 	endpoint.RawQuery = params.Encode()
 
-	req, err := http.NewRequest("Get", endpoint.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return errors.Wrap(err, "creating request")
 	}

--- a/pkg/logs/write.go
+++ b/pkg/logs/write.go
@@ -44,7 +44,7 @@ func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq *P
 		return errors.Wrap(err, "marshalling payload")
 	}
 
-	req, err = http.NewRequest("POST", endpoint.String(), bytes.NewBuffer(buf))
+	req, err = http.NewRequest(http.MethodPost, endpoint.String(), bytes.NewBuffer(buf))
 	if err != nil {
 		return errors.Wrap(err, "creating request")
 	}


### PR DESCRIPTION
Currently, the logs package makes a `Get` request when reading from
Loki, rather than a `GET` request. This is causing issues when
integrating with the Observatorium API. This commit fixes that by using
the standard libraries constants for specifying request types.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @periklis