### PR TITLE
Add option to read logs from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Usage of ./up:
     	The log filtering level. Options: 'error', 'warn', 'info', 'debug'. (default "info")
   -logs value
     	The logs that should be sent to remote-write requests.
+  -logs-file string
+    	A file containing logs to send against the logs write endpoint.
   -name string
     	The name of the metric to send in remote-write requests. (default "up")
   -period duration

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -45,6 +45,10 @@ const (
 	MetricsEndpointType EndpointType = "metrics"
 )
 
+type LogsSpec struct {
+	Logs logs `yaml:"logs"`
+}
+
 type QuerySpec struct {
 	Name  string `yaml:"name"`
 	Query string `yaml:"query"`


### PR DESCRIPTION
This PR addresses an enhancement to read logs to be written against the logs endpoint via a file. It enables up-front logs generation on runtime that are pinned on timestamps, e.g. via an init container. This is a mandatory step for non-flaky E2E testing of loki.

/cc @squat 