### PR TITLE
Update default step value to 5min

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Usage of ./up:
   -queries-file string
     	A file containing queries to run against the read endpoint.
   -step duration
-    	Default step duration for range queries. Can be overridden if step is set in query spec. (default 30s)
+    	Default step duration for range queries. Can be overridden if step is set in query spec. (default 5m0s)
   -threshold float
     	The percentage of successful requests needed to succeed overall. 0 - 1. (default 0.9)
   -tls-ca-file string

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -384,7 +384,7 @@ func parseFlags(l log.Logger) (options.Options, error) {
 		"The maximum allowable latency between writing and reading.")
 	flag.DurationVar(&opts.InitialQueryDelay, "initial-query-delay", 5*time.Second,
 		"The time to wait before executing the first query.")
-	flag.DurationVar(&opts.DefaultStep, "step", 30*time.Second, "Default step duration for range queries. "+
+	flag.DurationVar(&opts.DefaultStep, "step", 5*time.Minute, "Default step duration for range queries. "+
 		"Can be overridden if step is set in query spec.")
 
 	flag.StringVar(&opts.TLS.Cert, "tls-client-cert-file", "",


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

Update the default step value from 30s to 5min.

30s is a very small resolution for the range queries we might want to run (duration is 2w), and it will get the error below:

```
{"status":"error","errorType":"bad_data","error":"exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)"}
```

5min seems a good resolution for 2w queriers. But maybe we can increase it more since if I run 2w queries in Prometheus console, the step I got is `4838s`, but I think this resolution is too big.