### PR TITLE
Add cache option to query config

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -56,7 +56,7 @@ func apiError(code int) bool {
 	return code == statusAPIError || code == http.StatusBadRequest
 }
 
-// 1ueryResult contains result data for a query.
+// queryResult contains result data for a query.
 type queryResult struct {
 	Type   model.ValueType `json:"resultType"`
 	Result interface{}     `json:"result"`

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -152,8 +152,8 @@ func do(ctx context.Context, client promapi.Client, req *http.Request) (*http.Re
 	return resp, result.Data, result.Warnings, err
 }
 
-// DoGetFallback will attempt to do the request as-is, and on a 405 it will fallback to a GET request.
-func DoGetFallback(
+// doGetFallback will attempt to do the request as-is, and on a 405 it will fallback to a GET request.
+func doGetFallback(
 	ctx context.Context,
 	client promapi.Client,
 	u *url.URL,
@@ -196,7 +196,7 @@ func QueryRange(ctx context.Context, client promapi.Client, query string, r prom
 	q.Set("end", formatTime(r.End))
 	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
 
-	_, body, warnings, err := DoGetFallback(ctx, client, u, q, cache) //nolint:bodyclose
+	_, body, warnings, err := doGetFallback(ctx, client, u, q, cache) //nolint:bodyclose
 	if err != nil {
 		return nil, warnings, err
 	}
@@ -216,7 +216,7 @@ func Query(ctx context.Context, client promapi.Client, query string, ts time.Tim
 	}
 
 	// Instant query doesn't support cache
-	_, body, warnings, err := DoGetFallback(ctx, client, u, q, false) //nolint:bodyclose
+	_, body, warnings, err := doGetFallback(ctx, client, u, q, false) //nolint:bodyclose
 	if err != nil {
 		return nil, warnings, err
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,177 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a modified copy from https://github.com/prometheus/client_golang/blob/master/api/prometheus/v1/api.go.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	promapi "github.com/prometheus/client_golang/api"
+	promapiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	statusAPIError = 422
+
+	// Possible values for ErrorType.
+	ErrBadResponse promapiv1.ErrorType = "bad_response"
+	ErrServer      promapiv1.ErrorType = "server_error"
+	ErrClient      promapiv1.ErrorType = "client_error"
+
+	epQueryRange = "/api/v1/query_range"
+)
+
+func errorTypeAndMsgFor(resp *http.Response) (promapiv1.ErrorType, string) {
+	switch resp.StatusCode / 100 {
+	case 4:
+		return ErrClient, fmt.Sprintf("client error: %d", resp.StatusCode)
+	case 5:
+		return ErrServer, fmt.Sprintf("server error: %d", resp.StatusCode)
+	}
+	return ErrBadResponse, fmt.Sprintf("bad response code %d", resp.StatusCode)
+}
+
+func apiError(code int) bool {
+	// These are the codes that Prometheus sends when it returns an error.
+	return code == statusAPIError || code == http.StatusBadRequest
+}
+
+// queryResult contains result data for a query.
+type queryResult struct {
+	Type   model.ValueType `json:"resultType"`
+	Result interface{}     `json:"result"`
+
+	// The decoded value.
+	v model.Value
+}
+
+type apiResponse struct {
+	Status    string              `json:"status"`
+	Data      json.RawMessage     `json:"data"`
+	ErrorType promapiv1.ErrorType `json:"errorType"`
+	Error     string              `json:"error"`
+	Warnings  []string            `json:"warnings,omitempty"`
+}
+
+func do(ctx context.Context, client promapi.Client, req *http.Request) (*http.Response, []byte, promapiv1.Warnings, error) {
+	resp, body, err := client.Do(ctx, req)
+	if err != nil {
+		return resp, body, nil, err
+	}
+
+	code := resp.StatusCode
+
+	if code/100 != 2 && !apiError(code) {
+		errorType, errorMsg := errorTypeAndMsgFor(resp)
+		return resp, body, nil, &promapiv1.Error{
+			Type:   errorType,
+			Msg:    errorMsg,
+			Detail: string(body),
+		}
+	}
+
+	var result apiResponse
+
+	if http.StatusNoContent != code {
+		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
+			return resp, body, nil, &promapiv1.Error{
+				Type: ErrBadResponse,
+				Msg:  jsonErr.Error(),
+			}
+		}
+	}
+
+	if apiError(code) && result.Status == "success" {
+		err = &promapiv1.Error{
+			Type: ErrBadResponse,
+			Msg:  "inconsistent body for response code",
+		}
+	}
+
+	if result.Status == "error" {
+		err = &promapiv1.Error{
+			Type: result.ErrorType,
+			Msg:  result.Error,
+		}
+	}
+
+	return resp, result.Data, result.Warnings, err
+}
+
+// doGetFallback will attempt to do the request as-is, and on a 405 it will fallback to a GET request.
+func doGetFallback(
+	ctx context.Context,
+	client promapi.Client,
+	u *url.URL,
+	args url.Values,
+	cache bool,
+) (*http.Response, []byte, promapiv1.Warnings, error) {
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if !cache {
+		req.Header.Set("Cache-Control", "no-store")
+	}
+
+	resp, body, warnings, err := do(ctx, client, req)
+	if resp != nil && resp.StatusCode == http.StatusMethodNotAllowed {
+		u.RawQuery = args.Encode()
+		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, nil, warnings, err
+		}
+
+	} else {
+		if err != nil {
+			return resp, body, warnings, err
+		}
+		return resp, body, warnings, nil
+	}
+	return do(ctx, client, req)
+}
+
+func QueryRange(ctx context.Context, client promapi.Client, query string, r promapiv1.Range,
+	cache bool) (model.Value, promapiv1.Warnings, error) {
+	u := client.URL(epQueryRange, nil)
+	q := u.Query()
+
+	q.Set("query", query)
+	q.Set("start", formatTime(r.Start))
+	q.Set("end", formatTime(r.End))
+	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
+
+	_, body, warnings, err := doGetFallback(ctx, client, u, q, cache)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var qres queryResult
+
+	return qres.v, warnings, json.Unmarshal(body, &qres)
+}
+
+func formatTime(t time.Time) string {
+	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -38,7 +38,6 @@ const (
 	ErrServer      promapiv1.ErrorType = "server_error"
 	ErrClient      promapiv1.ErrorType = "client_error"
 
-	epQuery      = "/api/v1/query"
 	epQueryRange = "/api/v1/query_range"
 )
 
@@ -159,7 +158,7 @@ func doGetFallback(
 	u *url.URL,
 	args url.Values,
 	cache bool,
-) (*http.Response, []byte, promapiv1.Warnings, error) {
+) (*http.Response, []byte, promapiv1.Warnings, error) { //nolint:unparam
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
 	if err != nil {
 		return nil, nil, nil, err
@@ -207,7 +206,7 @@ func QueryRange(ctx context.Context, client promapi.Client, query string, r prom
 }
 
 func Query(ctx context.Context, client promapi.Client, query string, ts time.Time) (model.Value, promapiv1.Warnings, error) {
-	u := client.URL(epQuery, nil)
+	u := client.URL("", nil)
 	q := u.Query()
 
 	q.Set("query", query)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -193,7 +193,7 @@ func QueryRange(ctx context.Context, client promapi.Client, query string, r prom
 	q.Set("end", formatTime(r.End))
 	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
 
-	_, data, warnings, err := doGetFallback(ctx, client, u, q, cache)
+	_, data, warnings, err := doGetFallback(ctx, client, u, q, cache) //nolint:bodyclose
 	if err != nil {
 		return nil, warnings, err
 	}
@@ -213,7 +213,7 @@ func Query(ctx context.Context, client promapi.Client, query string, ts time.Tim
 		q.Set("time", formatTime(ts))
 	}
 
-	_, data, warnings, err := doGetFallback(ctx, client, u, q, cache)
+	_, data, warnings, err := doGetFallback(ctx, client, u, q, cache) //nolint:bodyclose
 	if err != nil {
 		return nil, warnings, err
 	}

--- a/pkg/metrics/query.go
+++ b/pkg/metrics/query.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/observatorium/up/pkg/api"
 	"github.com/observatorium/up/pkg/auth"
 	"github.com/observatorium/up/pkg/options"
 	"github.com/observatorium/up/pkg/transport"
@@ -71,11 +72,11 @@ func Query(
 			step = query.Step
 		}
 
-		_, warn, err = a.QueryRange(ctx, query.Query, promapiv1.Range{
+		_, warn, err := api.QueryRange(ctx, c, query.Query, promapiv1.Range{
 			Start: time.Now().Add(-time.Duration(query.Duration)),
 			End:   time.Now(),
 			Step:  step,
-		})
+		}, query.Cache)
 		if err != nil {
 			err = fmt.Errorf("querying: %w", err)
 			return warn, err

--- a/pkg/metrics/read.go
+++ b/pkg/metrics/read.go
@@ -64,7 +64,7 @@ func Read(
 	query := fmt.Sprintf("{%s}", strings.Join(labelSelectors, ","))
 
 	ts := time.Now().Add(ago)
-	value, _, err := api.Query(ctx, client, query, ts)
+	value, _, err := api.Query(ctx, client, query, ts, false)
 	if err != nil {
 		return errors.Wrap(err, "query request failed")
 	}

--- a/pkg/metrics/read.go
+++ b/pkg/metrics/read.go
@@ -2,14 +2,13 @@ package metrics
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/observatorium/up/pkg/api"
 	"github.com/observatorium/up/pkg/auth"
 	"github.com/observatorium/up/pkg/instr"
 	"github.com/observatorium/up/pkg/options"
@@ -21,51 +20,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 )
-
-type queryResult struct {
-	Type   model.ValueType `json:"resultType"`
-	Result interface{}     `json:"result"`
-
-	v model.Value
-}
-
-// UnmarshalJSON writes a queryResult instance to a byte sequence supporting scalar, vector and matrics data payloads.
-func (qr *queryResult) UnmarshalJSON(b []byte) error {
-	v := struct {
-		Status string `json:"status"`
-		Data   struct {
-			Type   model.ValueType `json:"resultType"`
-			Result json.RawMessage `json:"result"`
-		} `json:"data"`
-	}{}
-
-	err := json.Unmarshal(b, &v)
-	if err != nil {
-		return err
-	}
-
-	switch v.Data.Type {
-	case model.ValScalar:
-		var sv model.Scalar
-		err = json.Unmarshal(v.Data.Result, &sv)
-		qr.v = &sv
-
-	case model.ValVector:
-		var vv model.Vector
-		err = json.Unmarshal(v.Data.Result, &vv)
-		qr.v = vv
-
-	case model.ValMatrix:
-		var mv model.Matrix
-		err = json.Unmarshal(v.Data.Result, &mv)
-		qr.v = mv
-
-	default:
-		err = errors.Errorf("unexpected value type %q", v.Data.Type)
-	}
-
-	return err
-}
 
 // Read executes query against Prometheus with the same labels to retrieve the written metrics back.
 func Read(
@@ -109,25 +63,13 @@ func Read(
 
 	query := fmt.Sprintf("{%s}", strings.Join(labelSelectors, ","))
 
-	q := endpoint.Query()
-	q.Set("query", query)
-
 	ts := time.Now().Add(ago)
-	if !ts.IsZero() {
-		q.Set("time", formatTime(ts))
-	}
-
-	_, body, err := doGetFallback(ctx, client, endpoint, q) //nolint:bodyclose
+	value, _, err := api.Query(ctx, client, query, ts)
 	if err != nil {
 		return errors.Wrap(err, "query request failed")
 	}
 
-	var result queryResult
-	if err := json.Unmarshal(body, &result); err != nil {
-		return errors.Wrap(err, "query response parse failed")
-	}
-
-	vec := result.v.(model.Vector)
+	vec := value.(model.Vector)
 	if len(vec) != 1 {
 		return errors.Errorf("expected one metric, got %d", len(vec))
 	}
@@ -143,38 +85,4 @@ func Read(
 	}
 
 	return nil
-}
-
-// doGetFallback will attempt to do the request as-is, and on a 405 it will fallback to a GET request.
-// Copied from the prometheus API client v1.2.1 (as it was removed afterwards).
-// https://github.com/prometheus/client_golang/blob/55450579111f95e3722cb93dec62fe9e847d6130/api/client.go#L64
-func doGetFallback(ctx context.Context, c promapi.Client, u *url.URL, args url.Values) (*http.Response, []byte, error) {
-	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(args.Encode()))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, body, err := c.Do(ctx, req)
-	if resp != nil && resp.StatusCode == http.StatusMethodNotAllowed {
-		u.RawQuery = args.Encode()
-		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
-
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		if err != nil {
-			return resp, body, err
-		}
-
-		return resp, body, nil
-	}
-
-	return c.Do(ctx, req)
-}
-
-func formatTime(t time.Time) string {
-	return strconv.FormatFloat(float64(t.Unix())+float64(t.Nanosecond())/1e9, 'f', -1, 64)
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -50,12 +50,12 @@ type LogsSpec struct {
 	Logs logs `yaml:"logs"`
 }
 
-// TODO(yeya24): Add a bool value to control cache behavior when available in thanos.
 type QuerySpec struct {
 	Name     string         `yaml:"name"`
 	Query    string         `yaml:"query"`
 	Duration model.Duration `yaml:"duration"`
 	Step     time.Duration  `yaml:"step"`
+	Cache    bool           `yaml:"cache"`
 }
 
 type labelArg []prompb.Label


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

Fixes https://issues.redhat.com/browse/OBS-353, also close #21.

Now an example query config might be:

``` yaml
queries:
- name: up without cache
  query: topk(10, count({__name__=~".+"}) by (__name__))
  duration: 1w
  cache: false
- name: up
  query: topk(10, count({__name__=~".+"}) by (__name__))
  duration: 1w
  cache: true
```
