### PR TITLE
Support labels API and refactor QuerySpec

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/parser"
 	"gopkg.in/yaml.v2"
@@ -37,17 +38,14 @@ const (
 	numOfEndpoints        = 2
 	timeoutBetweenQueries = 100 * time.Millisecond
 
-	// Labels for query type.
-	labelQuery      = "query"
-	labelQueryRange = "query_range"
-	labelSeries     = "series"
-
 	labelSuccess = "success"
 	labelError   = "error"
 )
 
 type queriesFile struct {
-	Queries []options.QuerySpec `yaml:"queries"`
+	Queries       []options.QuerySpec  `yaml:"queries"`
+	LabelQueries  []options.LabelSpec  `yaml:"label_queries"`
+	SeriesQueries []options.SeriesSpec `yaml:"series_queries"`
 }
 
 type logsFile struct {
@@ -197,7 +195,7 @@ func read(ctx context.Context, l log.Logger, m instr.Metrics, opts options.Optio
 	return nil
 }
 
-func query(ctx context.Context, l log.Logger, q options.QuerySpec, opts options.Options) (promapiv1.Warnings, error) {
+func query(ctx context.Context, l log.Logger, q options.Query, opts options.Options) (promapiv1.Warnings, error) {
 	switch opts.EndpointType {
 	case options.MetricsEndpointType:
 		return metrics.Query(ctx, l, opts.ReadEndpoint, opts.Token, q, opts.TLS, opts.DefaultStep)
@@ -236,34 +234,28 @@ func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opt
 						t := time.Now()
 						warn, err := query(ctx, l, q, opts)
 						duration := time.Since(t).Seconds()
-						queryType := labelQuery
-						if q.Duration > 0 {
-							if q.Query != "" {
-								queryType = labelQueryRange
-							} else if len(q.Matchers) > 0 {
-								queryType = labelSeries
-							}
-						}
+						queryType := q.GetType()
+						name := q.GetName()
 						if err != nil {
 							level.Info(l).Log(
 								"msg", "failed to execute specified query",
 								"type", queryType,
-								"name", q.Name,
+								"name", name,
 								"duration", duration,
 								"warnings", fmt.Sprintf("%#+v", warn),
 								"err", err,
 							)
-							m.CustomQueryErrors.WithLabelValues(queryType, q.Name).Inc()
+							m.CustomQueryErrors.WithLabelValues(queryType, name).Inc()
 						} else {
 							level.Debug(l).Log("msg", "successfully executed specified query",
 								"type", queryType,
-								"name", q.Name,
+								"name", name,
 								"duration", duration,
 								"warnings", fmt.Sprintf("%#+v", warn),
 							)
-							m.CustomQueryLastDuration.WithLabelValues(queryType, q.Name).Set(duration)
+							m.CustomQueryLastDuration.WithLabelValues(queryType, name).Set(duration)
 						}
-						m.CustomQueryExecuted.WithLabelValues(queryType, q.Name).Inc()
+						m.CustomQueryExecuted.WithLabelValues(queryType, name).Inc()
 					}
 					time.Sleep(timeoutBetweenQueries)
 				}
@@ -534,22 +526,33 @@ func parseQueriesFileName(opts *options.Options, l log.Logger, queriesFileName s
 
 		// validate queries
 		for _, q := range qf.Queries {
-			if len(q.Matchers) > 0 {
-				for _, s := range q.Matchers {
-					if _, err := parser.ParseMetricSelector(s); err != nil {
-						return fmt.Errorf("query %q in --queries-file matchers are invalid: %w", q.Name, err)
-					}
-				}
-				continue
-			}
-
 			_, err = parser.ParseExpr(q.Query)
 			if err != nil {
 				return fmt.Errorf("query %q in --queries-file content is invalid: %w", q.Name, err)
 			}
+			opts.Queries = append(opts.Queries, q)
 		}
 
-		opts.Queries = qf.Queries
+		for _, q := range qf.SeriesQueries {
+			if len(q.Matchers) == 0 {
+				return fmt.Errorf("series query %q in --queries-file matchers cannot be empty", q.Name)
+			}
+			if len(q.Matchers) > 0 {
+				for _, s := range q.Matchers {
+					if _, err := parser.ParseMetricSelector(s); err != nil {
+						return fmt.Errorf("series query %q in --queries-file matchers are invalid: %w", q.Name, err)
+					}
+				}
+			}
+			opts.Queries = append(opts.Queries, q)
+		}
+
+		for _, q := range qf.LabelQueries {
+			if len(q.Label) > 0 && !model.LabelNameRE.MatchString(q.Label) {
+				return fmt.Errorf("label_values query %q in --queries-file label is invalid: %w", q.Name, err)
+			}
+			opts.Queries = append(opts.Queries, q)
+		}
 	}
 
 	return nil

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -42,10 +42,10 @@ const (
 	labelError   = "error"
 )
 
-type queriesFile struct {
-	Queries       []options.QuerySpec  `yaml:"queries"`
-	LabelQueries  []options.LabelSpec  `yaml:"label_queries"`
-	SeriesQueries []options.SeriesSpec `yaml:"series_queries"`
+type callsFile struct {
+	Queries []options.QuerySpec  `yaml:"queries"`
+	Labels  []options.LabelSpec  `yaml:"labels"`
+	Series  []options.SeriesSpec `yaml:"series"`
 }
 
 type logsFile struct {
@@ -515,7 +515,7 @@ func parseQueriesFileName(opts *options.Options, l log.Logger, queriesFileName s
 			return fmt.Errorf("--queries-file is invalid: %w", err)
 		}
 
-		qf := queriesFile{}
+		qf := callsFile{}
 		err = yaml.Unmarshal(b, &qf)
 
 		if err != nil {
@@ -533,7 +533,7 @@ func parseQueriesFileName(opts *options.Options, l log.Logger, queriesFileName s
 			opts.Queries = append(opts.Queries, q)
 		}
 
-		for _, q := range qf.SeriesQueries {
+		for _, q := range qf.Series {
 			if len(q.Matchers) == 0 {
 				return fmt.Errorf("series query %q in --queries-file matchers cannot be empty", q.Name)
 			}
@@ -547,7 +547,7 @@ func parseQueriesFileName(opts *options.Options, l log.Logger, queriesFileName s
 			opts.Queries = append(opts.Queries, q)
 		}
 
-		for _, q := range qf.LabelQueries {
+		for _, q := range qf.Labels {
 			if len(q.Label) > 0 && !model.LabelNameRE.MatchString(q.Label) {
 				return fmt.Errorf("label_values query %q in --queries-file label is invalid: %w", q.Name, err)
 			}

--- a/pkg/logs/query.go
+++ b/pkg/logs/query.go
@@ -24,10 +24,15 @@ func Query(
 	l log.Logger,
 	endpoint *url.URL,
 	t auth.TokenProvider,
-	query options.QuerySpec,
+	q options.Query,
 	tls options.TLS,
 	defaultStep time.Duration,
 ) (promapiv1.Warnings, error) {
+	// TODO: avoid type casting when we need to support all query endpoints for logs.
+	query, ok := q.(*options.QuerySpec)
+	if !ok {
+		return nil, errors.New("Incorrect query type for logs queries")
+	}
 	level.Debug(l).Log("msg", "running specified query", "name", query.Name, "query", query.Query)
 
 	var (

--- a/pkg/logs/types.go
+++ b/pkg/logs/types.go
@@ -8,7 +8,7 @@ type queryResponse struct {
 	} `json:"data"`
 }
 
-// PushRequest reprents the payload to push logs to Loki.
+// PushRequest represents the payload to push logs to Loki.
 type PushRequest struct {
 	Streams []stream `json:"streams"`
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,7 @@ type Options struct {
 	Listen            string
 	Name              string
 	Token             auth.TokenProvider
-	Queries           []QuerySpec
+	Queries           []Query
 	Period            time.Duration
 	Duration          time.Duration
 	Latency           time.Duration
@@ -48,15 +48,6 @@ const (
 
 type LogsSpec struct {
 	Logs logs `yaml:"logs"`
-}
-
-type QuerySpec struct {
-	Name     string         `yaml:"name"`
-	Query    string         `yaml:"query"`
-	Matchers []string       `yaml:"matchers"`
-	Duration model.Duration `yaml:"duration"`
-	Step     time.Duration  `yaml:"step"`
-	Cache    bool           `yaml:"cache"`
 }
 
 type labelArg []prompb.Label

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	// Labels for query type.
+	// Labels for query types.
 	labelQuery      = "query"
 	labelQueryRange = "query_range"
 	labelSeries     = "series"

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -1,0 +1,163 @@
+package options
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/observatorium/up/pkg/api"
+	promapi "github.com/prometheus/client_golang/api"
+	promapiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	// Labels for query type.
+	labelQuery      = "query"
+	labelQueryRange = "query_range"
+	labelSeries     = "series"
+	labelNames      = "label_names"
+	labelValues     = "label_values"
+)
+
+// Query represents different types of queries.
+type Query interface {
+	// GetName gets the name of the query.
+	GetName() string
+	// GetType gets the query type.
+	GetType() string
+	// GetQuery gets the query statement (promql) or label/matchers of the query.
+	GetQuery() string
+	// Run executes the query.
+	Run(ctx context.Context, c promapi.Client, logger log.Logger, traceID string,
+		defaultStep time.Duration) (promapiv1.Warnings, error)
+}
+
+type QuerySpec struct {
+	Name     string         `yaml:"name"`
+	Query    string         `yaml:"query"`
+	Duration model.Duration `yaml:"duration,omitempty"`
+	Step     time.Duration  `yaml:"step,omitempty"`
+	Cache    bool           `yaml:"cache,omitempty"`
+}
+
+func (q QuerySpec) GetName() string {
+	return q.Name
+}
+
+func (q QuerySpec) GetType() string {
+	if q.Duration > 0 {
+		return labelQueryRange
+	}
+	return labelQuery
+}
+
+func (q QuerySpec) GetQuery() string { return q.Query }
+
+func (q QuerySpec) Run(ctx context.Context, c promapi.Client, logger log.Logger, traceID string,
+	defaultStep time.Duration) (promapiv1.Warnings, error) {
+	var (
+		warn promapiv1.Warnings
+		err  error
+	)
+	if q.Duration > 0 {
+		step := defaultStep
+		if q.Step > 0 {
+			step = q.Step
+		}
+
+		_, warn, err = api.QueryRange(ctx, c, q.Query, promapiv1.Range{
+			Start: time.Now().Add(-time.Duration(q.Duration)),
+			End:   time.Now(),
+			Step:  step,
+		}, q.Cache)
+		if err != nil {
+			err = fmt.Errorf("querying: %w", err)
+			return warn, err
+		}
+
+		// Don't log response in range query case because there are a lot.
+		level.Debug(logger).Log("msg", "request finished", "name", q.Name, "trace-id", traceID)
+		return warn, err
+	}
+
+	var res model.Value
+	a := promapiv1.NewAPI(c)
+	res, warn, err = a.Query(ctx, q.Query, time.Now())
+	if err != nil {
+		err = fmt.Errorf("querying: %w", err)
+		return warn, err
+	}
+
+	level.Debug(logger).Log("msg", "request finished", "name", q.Name, "response", res.String(), "trace-id", traceID)
+
+	return warn, err
+}
+
+type LabelSpec struct {
+	Name     string         `yaml:"name"`
+	Label    string         `yaml:"label"`
+	Duration model.Duration `yaml:"duration"`
+	Cache    bool           `yaml:"cache"`
+}
+
+func (q LabelSpec) GetName() string { return q.Name }
+
+func (q LabelSpec) GetType() string {
+	if len(q.Label) > 0 {
+		return labelValues
+	}
+	return labelNames
+}
+
+func (q LabelSpec) GetQuery() string { return q.Label }
+
+func (q LabelSpec) Run(ctx context.Context, c promapi.Client, logger log.Logger, traceID string,
+	_ time.Duration) (promapiv1.Warnings, error) {
+	var (
+		warn promapiv1.Warnings
+		err  error
+	)
+	if len(q.Label) > 0 {
+		_, warn, err = api.LabelValues(ctx, c, q.Label, time.Now().Add(-time.Duration(q.Duration)), time.Now(), q.Cache)
+	} else {
+		_, warn, err = api.LabelNames(ctx, c, time.Now().Add(-time.Duration(q.Duration)), time.Now(), q.Cache)
+	}
+	if err != nil {
+		err = fmt.Errorf("querying: %w", err)
+		return warn, err
+	}
+
+	// Don't log responses because there are a lot.
+	level.Debug(logger).Log("msg", "request finished", "name", q.Name, "trace-id", traceID)
+	return warn, err
+}
+
+type SeriesSpec struct {
+	Name     string         `yaml:"name"`
+	Matchers []string       `yaml:"matchers"`
+	Duration model.Duration `yaml:"duration"`
+	Cache    bool           `yaml:"cache"`
+}
+
+func (q SeriesSpec) GetName() string { return q.Name }
+
+func (q SeriesSpec) GetType() string { return labelSeries }
+
+func (q SeriesSpec) GetQuery() string { return strings.Join(q.Matchers, ", ") }
+
+func (q SeriesSpec) Run(ctx context.Context, c promapi.Client, logger log.Logger, traceID string,
+	_ time.Duration) (promapiv1.Warnings, error) {
+	_, warn, err := api.Series(ctx, c, q.Matchers, time.Now().Add(-time.Duration(q.Duration)), time.Now(), q.Cache)
+	if err != nil {
+		err = fmt.Errorf("querying: %w", err)
+		return warn, err
+	}
+
+	// Don't log responses because there are a lot.
+	level.Debug(logger).Log("msg", "request finished", "name", q.Name, "trace-id", traceID)
+	return warn, err
+}


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

Did a refactoring for the `QuerySpec` and makes `Query` an interface.

I only changed the queries for `metrics` and didn't touch much of the `logs` part. We can refactor it later if needed.

Now the query config file for metrics looks like below, there are 3 sections for normal queries, series queries and range queries.

```
queries:
- name: up without cache
  query: topk(10, count({__name__=~".+"}) by (__name__))
  duration: 1w
  cache: false
- name: up
  query: topk(10, count({__name__=~".+"}) by (__name__))
  duration: 1w
  cache: true

series_queries:
- name: test
  matchers: 
  - '{instance!=""}'
  duration: 1w
  cache: false

label_queries:
- name: label_names
  cache: true
  duration: 1w
- name: label_values
  label: instance
  duration: 1w
  cache: true 
```