### PR TITLE
Add read & write path latency instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.tags
 /vendor
 /tmp
+/.idea

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -52,7 +52,7 @@ type logsFile struct {
 	Spec options.LogsSpec `yaml:"spec"`
 }
 
-func main() {
+func main() { //nolint:golint,funlen
 	l := log.WithPrefix(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), "name", "up")
 	l = log.WithPrefix(l, "ts", log.DefaultTimestampUTC)
 	l = log.WithPrefix(l, "caller", log.DefaultCaller)

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -245,7 +245,6 @@ func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opt
 						duration := time.Since(t).Seconds()
 						queryType := q.GetType()
 						name := q.GetName()
-
 						if err != nil {
 							level.Info(l).Log(
 								"msg", "failed to execute specified query",

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -108,7 +108,11 @@ func main() {
 			level.Info(l).Log("msg", "starting the writer")
 
 			return runPeriodically(ctx, opts, m.RemoteWriteRequests, l, ch, func(rCtx context.Context) {
-				if err := write(rCtx, l, opts); err != nil {
+				t := time.Now()
+				err := write(rCtx, l, opts)
+				duration := time.Since(t).Seconds()
+				m.RemoteWriteRequestDuration.Observe(duration)
+				if err != nil {
 					m.RemoteWriteRequests.WithLabelValues(labelError).Inc()
 					level.Error(l).Log("msg", "failed to make request", "err", err)
 				} else {
@@ -136,7 +140,11 @@ func main() {
 			level.Info(l).Log("msg", "start querying", "type", opts.EndpointType)
 
 			return runPeriodically(ctx, opts, m.QueryResponses, l, ch, func(rCtx context.Context) {
-				if err := read(rCtx, l, m, opts); err != nil {
+				t := time.Now()
+				err := read(rCtx, l, m, opts)
+				duration := time.Since(t).Seconds()
+				m.QueryResponseDuration.Observe(duration)
+				if err != nil {
 					m.QueryResponses.WithLabelValues(labelError).Inc()
 					level.Error(l).Log("msg", "failed to query", "err", err)
 				} else {
@@ -237,6 +245,7 @@ func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opt
 						duration := time.Since(t).Seconds()
 						queryType := q.GetType()
 						name := q.GetName()
+
 						if err != nil {
 							level.Info(l).Log(
 								"msg", "failed to execute specified query",
@@ -257,6 +266,7 @@ func addCustomQueryRunGroup(ctx context.Context, g *run.Group, l log.Logger, opt
 							m.CustomQueryLastDuration.WithLabelValues(queryType, name).Set(duration)
 						}
 						m.CustomQueryExecuted.WithLabelValues(queryType, name).Inc()
+						m.CustomQueryRequestDuration.WithLabelValues(queryType, name).Observe(duration)
 					}
 					time.Sleep(timeoutBetweenQueries)
 				}

--- a/go.sum
+++ b/go.sum
@@ -31,11 +31,9 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -97,7 +95,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
@@ -285,14 +282,12 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
-github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -618,7 +613,6 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/instr/metrics.go
+++ b/pkg/instr/metrics.go
@@ -32,8 +32,8 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 			Help: "The total number of queries made.",
 		}, []string{"result"}),
 		QueryResponseDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:        "up_queries_duration_seconds",
-			Help:        "Duration of up queries.",
+			Name: "up_queries_duration_seconds",
+			Help: "Duration of up queries.",
 		}),
 		MetricValueDifference: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "up_metric_value_difference",
@@ -45,8 +45,8 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 			Help: "The total number of custom specified queries executed.",
 		}, []string{"type", "query"}),
 		CustomQueryRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:        "up_custom_query_duration_seconds",
-			Help:        "Duration of custom specified queries",
+			Name: "up_custom_query_duration_seconds",
+			Help: "Duration of custom specified queries",
 			// We deliberately chose quite large buckets as we want to be able to accurately measure heavy queries.
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 5, 10, 15, 20, 25, 30, 45, 60},
 		}, []string{"type", "query"}),

--- a/pkg/instr/metrics.go
+++ b/pkg/instr/metrics.go
@@ -6,12 +6,15 @@ import (
 )
 
 type Metrics struct {
-	RemoteWriteRequests     *prometheus.CounterVec
-	QueryResponses          *prometheus.CounterVec
-	MetricValueDifference   prometheus.Histogram
-	CustomQueryExecuted     *prometheus.CounterVec
-	CustomQueryErrors       *prometheus.CounterVec
-	CustomQueryLastDuration *prometheus.GaugeVec
+	RemoteWriteRequests        *prometheus.CounterVec
+	RemoteWriteRequestDuration prometheus.Histogram
+	QueryResponses             *prometheus.CounterVec
+	QueryResponseDuration      prometheus.Histogram
+	MetricValueDifference      prometheus.Histogram
+	CustomQueryExecuted        *prometheus.CounterVec
+	CustomQueryErrors          *prometheus.CounterVec
+	CustomQueryRequestDuration *prometheus.HistogramVec
+	CustomQueryLastDuration    *prometheus.GaugeVec
 }
 
 func RegisterMetrics(reg *prometheus.Registry) Metrics {
@@ -20,10 +23,18 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 			Name: "up_remote_writes_total",
 			Help: "Total number of remote write requests.",
 		}, []string{"result"}),
+		RemoteWriteRequestDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name: "up_remote_writes_duration_seconds",
+			Help: "Duration of remote write requests.",
+		}),
 		QueryResponses: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "up_queries_total",
 			Help: "The total number of queries made.",
 		}, []string{"result"}),
+		QueryResponseDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:        "up_queries_duration_seconds",
+			Help:        "Duration of up queries.",
+		}),
 		MetricValueDifference: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "up_metric_value_difference",
 			Help:    "The time difference between the current timestamp and the timestamp in the metrics value.",
@@ -32,6 +43,10 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 		CustomQueryExecuted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "up_custom_query_executed_total",
 			Help: "The total number of custom specified queries executed.",
+		}, []string{"type", "query"}),
+		CustomQueryRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:        "up_custom_query_duration_seconds",
+			Help:        "Duration of custom specified queries",
 		}, []string{"type", "query"}),
 		CustomQueryErrors: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "up_custom_query_errors_total",

--- a/pkg/instr/metrics.go
+++ b/pkg/instr/metrics.go
@@ -47,6 +47,8 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 		CustomQueryRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:        "up_custom_query_duration_seconds",
 			Help:        "Duration of custom specified queries",
+			// We deliberately chose quite large buckets as we want to be able to accurately measure heavy queries.
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 5, 10, 15, 20, 25, 30, 45, 60},
 		}, []string{"type", "query"}),
 		CustomQueryErrors: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "up_custom_query_errors_total",


### PR DESCRIPTION
This PR adds `Histogram` based latency intstrumentation to the query & remote_write parts of the `up` binary.

<details>
    <summary> Up Metrics page when run with `--queries.file` against a local Receive & Query instance. </summary>

 ```
# HELP up_custom_query_duration_seconds Duration of custom specified queries
# TYPE up_custom_query_duration_seconds histogram
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="0.1"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="0.25"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="0.5"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="1"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="5"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="10"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="15"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="20"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="25"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="30"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="45"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="60"} 446
up_custom_query_duration_seconds_bucket{query="ian",type="query",le="+Inf"} 446
up_custom_query_duration_seconds_sum{query="ian",type="query"} 1.5917340899999992
up_custom_query_duration_seconds_count{query="ian",type="query"} 446
# HELP up_custom_query_executed_total The total number of custom specified queries executed.
# TYPE up_custom_query_executed_total counter
up_custom_query_executed_total{query="ian",type="query"} 446
# HELP up_custom_query_last_duration The duration of the query execution last time the query was executed successfully.
# TYPE up_custom_query_last_duration gauge
up_custom_query_last_duration{query="ian",type="query"} 0.004152627
# HELP up_metric_value_difference The time difference between the current timestamp and the timestamp in the metrics value.
# TYPE up_metric_value_difference histogram
up_metric_value_difference_bucket{le="4"} 0
up_metric_value_difference_bucket{le="4.25"} 0
up_metric_value_difference_bucket{le="4.5"} 0
up_metric_value_difference_bucket{le="4.75"} 0
up_metric_value_difference_bucket{le="5"} 0
up_metric_value_difference_bucket{le="5.25"} 0
up_metric_value_difference_bucket{le="5.5"} 0
up_metric_value_difference_bucket{le="5.75"} 18
up_metric_value_difference_bucket{le="6"} 18
up_metric_value_difference_bucket{le="6.25"} 18
up_metric_value_difference_bucket{le="6.5"} 18
up_metric_value_difference_bucket{le="6.75"} 18
up_metric_value_difference_bucket{le="7"} 18
up_metric_value_difference_bucket{le="7.25"} 18
up_metric_value_difference_bucket{le="7.5"} 18
up_metric_value_difference_bucket{le="7.75"} 18
up_metric_value_difference_bucket{le="+Inf"} 18
up_metric_value_difference_sum 101.60254487799999
up_metric_value_difference_count 18
# HELP up_queries_duration_seconds Duration of up queries.
# TYPE up_queries_duration_seconds histogram
up_queries_duration_seconds_bucket{le="0.005"} 18
up_queries_duration_seconds_bucket{le="0.01"} 18
up_queries_duration_seconds_bucket{le="0.025"} 18
up_queries_duration_seconds_bucket{le="0.05"} 18
up_queries_duration_seconds_bucket{le="0.1"} 18
up_queries_duration_seconds_bucket{le="0.25"} 18
up_queries_duration_seconds_bucket{le="0.5"} 18
up_queries_duration_seconds_bucket{le="1"} 18
up_queries_duration_seconds_bucket{le="2.5"} 18
up_queries_duration_seconds_bucket{le="5"} 18
up_queries_duration_seconds_bucket{le="10"} 18
up_queries_duration_seconds_bucket{le="+Inf"} 18
up_queries_duration_seconds_sum 0.055578053999999995
up_queries_duration_seconds_count 18
# HELP up_queries_total The total number of queries made.
# TYPE up_queries_total counter
up_queries_total{result="success"} 18
# HELP up_remote_writes_duration_seconds Duration of remote write requests.
# TYPE up_remote_writes_duration_seconds histogram
up_remote_writes_duration_seconds_bucket{le="0.005"} 19
up_remote_writes_duration_seconds_bucket{le="0.01"} 19
up_remote_writes_duration_seconds_bucket{le="0.025"} 19
up_remote_writes_duration_seconds_bucket{le="0.05"} 19
up_remote_writes_duration_seconds_bucket{le="0.1"} 19
up_remote_writes_duration_seconds_bucket{le="0.25"} 19
up_remote_writes_duration_seconds_bucket{le="0.5"} 19
up_remote_writes_duration_seconds_bucket{le="1"} 19
up_remote_writes_duration_seconds_bucket{le="2.5"} 19
up_remote_writes_duration_seconds_bucket{le="5"} 19
up_remote_writes_duration_seconds_bucket{le="10"} 19
up_remote_writes_duration_seconds_bucket{le="+Inf"} 19
up_remote_writes_duration_seconds_sum 0.028023073
up_remote_writes_duration_seconds_count 19
# HELP up_remote_writes_total Total number of remote write requests.
# TYPE up_remote_writes_total counter
up_remote_writes_total{result="success"} 19
```

</details>