### PR TITLE
Use exponential buckets when measuring query latency

### DIFF
--- a/pkg/instr/metrics.go
+++ b/pkg/instr/metrics.go
@@ -48,7 +48,7 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 			Name: "up_custom_query_duration_seconds",
 			Help: "Duration of custom specified queries",
 			// We deliberately chose quite large buckets as we want to be able to accurately measure heavy queries.
-			Buckets: []float64{0.1, 0.25, 0.5, 1, 5, 10, 15, 20, 25, 30, 45, 60},
+			Buckets: prometheus.ExponentialBuckets(1, 1.15, 30),
 		}, []string{"type", "query"}),
 		CustomQueryErrors: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "up_custom_query_errors_total",


### PR DESCRIPTION
Since this has now been running for a bit, we can see the rough shape of the data we will get from the modified up binary.

Now, we are bound to the intervals set in the  `up_custom_query_duration_seconds` metric.

This PR expands the set of buckets that we use to monitor query path latencies. Yes, exposing 30 metrics per query is quite a lot, but we only run one `Up` binary per instance so the overhead is worth it to see a finer grain detail of query path latencies.

![image](https://user-images.githubusercontent.com/33524269/137519169-67980753-d8b1-4f98-af89-3795c09d26b6.png)

Signed-off-by: Ian Billett <ibillett@redhat.com>