### PR TITLE
Check empty `rCtx` to prevent panic

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -314,11 +314,13 @@ func runPeriodically(ctx context.Context, opts options.Options, c *prometheus.Co
 		case <-ctx.Done():
 			t.Stop()
 
-			select {
-			// If it gets immediately cancelled, zero value of deadline won't cause a lock!
-			case <-time.After(time.Until(deadline)):
-				rCancel()
-			case <-rCtx.Done():
+			if rCtx != nil {
+				select {
+				// If it gets immediately cancelled, zero value of deadline won't cause a lock!
+				case <-time.After(time.Until(deadline)):
+					rCancel()
+				case <-rCtx.Done():
+				}
 			}
 
 			return reportResults(l, ch, c, opts.SuccessThreshold)


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

In some scenarios (this happens for me with read/write configured, when the first write fails), it's possible the main context is done while there is no in-flight request context. However, we still check for `rCtx.Done()` in the other `select` branch, causing the program to panic, since `rCtx` is `nil`. This PR fixes the issue.