### PR TITLE
Record the HTTP status code when receiving writes

### DIFF
--- a/pkg/instr/metrics.go
+++ b/pkg/instr/metrics.go
@@ -22,7 +22,7 @@ func RegisterMetrics(reg *prometheus.Registry) Metrics {
 		RemoteWriteRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "up_remote_writes_total",
 			Help: "Total number of remote write requests.",
-		}, []string{"result"}),
+		}, []string{"result", "http_code"}),
 		RemoteWriteRequestDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name: "up_remote_writes_duration_seconds",
 			Help: "Duration of remote write requests.",

--- a/pkg/logs/write.go
+++ b/pkg/logs/write.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Write executes a push against Loki sending a set of labels and log entries to store.
-func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq *PushRequest, l log.Logger, tls options.TLS) error {
+func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq *PushRequest, l log.Logger, tls options.TLS) (int, error) {
 	var (
 		buf []byte
 		err error
@@ -29,7 +29,7 @@ func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq *P
 	if endpoint.Scheme == transport.HTTPS {
 		rt, err = transport.NewTLSTransport(l, tls)
 		if err != nil {
-			return errors.Wrap(err, "create round tripper")
+			return 0, errors.Wrap(err, "create round tripper")
 		}
 
 		rt = auth.NewBearerTokenRoundTripper(l, t, rt)
@@ -41,29 +41,29 @@ func Write(ctx context.Context, endpoint *url.URL, t auth.TokenProvider, wreq *P
 
 	buf, err = json.Marshal(wreq)
 	if err != nil {
-		return errors.Wrap(err, "marshalling payload")
+		return 0, errors.Wrap(err, "marshalling payload")
 	}
 
 	req, err = http.NewRequest(http.MethodPost, endpoint.String(), bytes.NewBuffer(buf))
 	if err != nil {
-		return errors.Wrap(err, "creating request")
+		return 0, errors.Wrap(err, "creating request")
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err = client.Do(req.WithContext(ctx)) //nolint:bodyclose
 	if err != nil {
-		return errors.Wrap(err, "making request")
+		return 0, errors.Wrap(err, "making request")
 	}
 
 	defer transport.ExhaustCloseWithLogOnErr(l, res.Body)
 
 	if res.StatusCode != http.StatusNoContent {
 		err = errors.Errorf(res.Status)
-		return errors.Wrap(err, "non-204 status")
+		return res.StatusCode, errors.Wrap(err, "non-204 status")
 	}
 
-	return nil
+	return res.StatusCode, nil
 }
 
 // Generate takes a set of labels and log lines and returns the payload to push logs to Loki.


### PR DESCRIPTION
It puts the instrumentation for `writes` on par with `reads`, allowing users of `up` to check the HTTP code of failed writes.

Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>