### PR TITLE
Build & publish multi arch image

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Import environment variables from file
       run: cat ".github/env" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
     - run: make --always-make lint && git diff --exit-code
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Import environment variables from file
       run: cat ".github/env" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
     - run: make --always-make generate && git diff --exit-code
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Import environment variables from file
       run: cat ".github/env" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
     - run: make up

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
+        cache: true
     - run: make --always-make lint && git diff --exit-code
   generate:
     runs-on: ubuntu-latest
@@ -33,6 +34,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
+        cache: true
     - run: make --always-make generate && git diff --exit-code
   build:
     runs-on: ${{ matrix.os }}
@@ -48,4 +50,5 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
+        cache: true
     - run: make up

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,36 +1,67 @@
-name: publish
+name: Container build & push jobs
+
 on:
   push:
     branches:
-      - 'master'
-      - 'main'
+      - master
+      - main
     tags:
-      - 'v*'
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
 jobs:
-  image:
+  build_push_container:
     runs-on: ubuntu-latest
+    name: Build and push the container image for a commit or tag.
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code into the Go module directory.
+        uses: actions/checkout@v3
+
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - name: Login to image registry
-        uses: docker/login-action@v1
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '${{ env.golang-version }}'
+
+      - name: Cache for Go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Generate image names
-        id: images
-        run: |
-          echo -n ::set-output name=IMAGES::
-          TAGS=($echo '${{ env.image-repository }}:latest')
-          tag=($echo "${{ env.image-repository }}:$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)")
-          TAGS+=($echo $(echo $tag | awk '{ print tolower($1) }'))
-          ( IFS=$','; echo "${TAGS[*]}" )
-      - name: Build and publish image(s) to registry
-        uses: docker/build-push-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache for Docker's buildx
+        uses: actions/cache@v3
         with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: "${{ steps.images.outputs.IMAGES }}"
+          path: .buildxcache/
+          key: ${{ runner.os }}-buildx-${{ hashFiles('**/*.go', 'Dockerfile', 'go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Snapshot container buid & push
+        run: make conditional-container-build-push
+
+      - name: Check semver tag
+        id: check-semver-tag
+        # The regex below comes from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$ ]]; then
+              echo ::set-output name=match::true
+          fi
+      - name: Release container build & push
+        if: steps.check-semver-tag.outputs.match == 'true'
+        run: make container-release-build-push

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,28 +16,6 @@ jobs:
       - name: Checkout code into the Go module directory.
         uses: actions/checkout@v3
 
-      - name: Import environment variables from file
-        run: cat ".github/env" >> $GITHUB_ENV
-
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '${{ env.golang-version }}'
-
-      - name: Cache for Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Login to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '${{ env.golang-version }}'
       - run: make test
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '${{ env.golang-version }}'
       - run: make test-integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '${{ env.golang-version }}'
+          cache: true
       - run: make test
   integration-tests:
     runs-on: ${{ matrix.os }}
@@ -37,4 +38,5 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '${{ env.golang-version }}'
+          cache: true
       - run: make test-integration


### PR DESCRIPTION
Cross-compile the project using buildx to push multi-arch images. Based on the work done in https://github.com/observatorium/token-refresher.

As a test, I published the image to https://quay.io/repository/douglascamata/up-test?tab=tags.

Some extras: 

* Upgraded the `setup-go` action to v3
* Use the cache feature that is included in the `setup-go` action. Helps cleaning up a bit and delegating the caching responsibility.
* Removed the `setup-go` action from container building workflows. These use the builder container's Go to compile the project.